### PR TITLE
Consume spytial-core 1.9.7

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -7,9 +7,9 @@
     
     <script src="https://d3js.org/d3.v4.min.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/spytial-core@1.9.3/dist/browser/spytial-core-complete.global.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/spytial-core@1.9.3/dist/components/react-component-integration.global.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/spytial-core@1.9.3/dist/components/react-component-integration.css" /> 
+    <script src="https://cdn.jsdelivr.net/npm/spytial-core@1.9.7/dist/browser/spytial-core-complete.global.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/spytial-core@1.9.7/dist/components/react-component-integration.global.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/spytial-core@1.9.7/dist/components/react-component-integration.css" /> 
     
     <style>
         body {


### PR DESCRIPTION
## Summary
- update the embedded spytial-core CDN assets to 1.9.7
- keep the Rust HTML renderer aligned with the current spytial-core release

## Testing
- cargo test --lib --tests