### PR TITLE
Add representative RB tree example and Docker-served visualization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+target
+*.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM rust:1-bookworm AS builder
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY macros/Cargo.toml macros/Cargo.toml
+COPY macros/src macros/src
+COPY src src
+COPY templates templates
+COPY examples examples
+
+RUN cargo build --release --examples --bin viz_server
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/examples/ /app/examples/
+COPY --from=builder /app/target/release/viz_server /usr/local/bin/viz-server
+COPY docker-entrypoint.sh /usr/local/bin/caraspace-example
+RUN chmod +x /usr/local/bin/caraspace-example /usr/local/bin/viz-server
+
+ENV SPYTIAL_NO_OPEN=1
+ENV SPYTIAL_PORT=8080
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/caraspace-example"]
+CMD ["rbt"]

--- a/README.md
+++ b/README.md
@@ -66,20 +66,45 @@ The compile-time analysis supports:
 
 
 
+## Representative Examples
+
+- `cargo run --example demo` shows decorator collection on nested business-domain structs.
+- `cargo run --example rbt` builds an insertion-balanced red-black tree (LLRB style) and renders it with node color/layout decorators.
+
 ## 🛠 Development
 
-Run the example:
-```bash
-cargo run --example demo
-```
-
-Check for issues:
 ```bash
 cargo test --lib --tests
 cargo test --doc
+cargo run --example demo
+cargo run --example rbt
 ```
 
-The example demonstrates a `Company` with `Vec<Person>` where both types have decorators, and shows how all decorators are automatically collected without manual registration.
+## Docker
+
+Build the image:
+
+```bash
+docker build -t caraspace .
+```
+
+Run the default red-black tree example:
+
+```bash
+docker run --rm -p 8080:8080 caraspace
+```
+
+Run a different example:
+
+```bash
+docker run --rm -p 8080:8080 caraspace demo
+```
+
+When the example finishes, the container starts a small HTTP server and logs:
+
+`Visualization server ready at http://localhost:8080/rust_viz_data.html`
+
+Open that URL in your host browser. Browser launch inside the container stays disabled (`SPYTIAL_NO_OPEN=1`).
 
 
 ## License

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -151,7 +151,33 @@ That path is better suited to advanced integrations than to the normal “derive
 cargo test --lib --tests
 cargo test --doc
 cargo run --example demo
+cargo run --example rbt
 ```
+
+The `rbt` example is a representative insertion-balanced red-black tree (LLRB style) with decorator-driven coloring and left/right layout constraints.
+
+## Docker Quickstart
+
+Build:
+
+```bash
+docker build -t caraspace .
+```
+
+Run the red-black tree example (default):
+
+```bash
+docker run --rm -p 8080:8080 caraspace
+```
+
+Run a specific example:
+
+```bash
+docker run --rm -p 8080:8080 caraspace demo
+```
+
+In Docker, browser launch is disabled (`SPYTIAL_NO_OPEN=1`), so no GUI is opened inside the container.
+After the example runs, the container serves the generated visualization at `http://localhost:8080/rust_viz_data.html`.
 
 ## Limitations and Expectations
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -eu
+
+example="${1:-rbt}"
+if [ "$#" -gt 0 ]; then
+    shift
+fi
+
+binary="/app/examples/${example}"
+if [ ! -x "${binary}" ]; then
+    echo "Unknown example '${example}'." >&2
+    echo "Available examples:" >&2
+    ls -1 /app/examples >&2
+    exit 1
+fi
+
+echo "Running example '${example}'..."
+"${binary}" "$@"
+
+if [ ! -f /tmp/rust_viz_data.html ]; then
+    echo "Expected visualization file was not generated at /tmp/rust_viz_data.html" >&2
+    exit 1
+fi
+
+echo "Starting visualization server..."
+exec /usr/local/bin/viz-server /tmp/rust_viz_data.html

--- a/examples/rbt.rs
+++ b/examples/rbt.rs
@@ -25,10 +25,19 @@ struct RBNode {
 
 /// Color of a node in the red-black tree
 /// Deriving SpytialDecorators on enums is supported - they just have empty decorators
-#[derive(Serialize, SpytialDecorators, Debug, Clone, Copy)]
+#[derive(Serialize, SpytialDecorators, Debug, Clone, Copy, PartialEq, Eq)]
 enum Color {
     Red,
     Black,
+}
+
+impl Color {
+    fn flipped(self) -> Self {
+        match self {
+            Color::Red => Color::Black,
+            Color::Black => Color::Red,
+        }
+    }
 }
 
 impl RBNode {
@@ -41,20 +50,122 @@ impl RBNode {
         }
     }
 
-    fn insert(&mut self, key: u32) {
-        if key < self.key {
-            match &mut self.left {
-                Some(left) => left.insert(key),
-                None => {
-                    self.left = Some(Box::new(RBNode::new(key, Color::Red)));
+    fn is_red(node: &Option<Box<RBNode>>) -> bool {
+        matches!(node.as_ref().map(|n| n.color), Some(Color::Red))
+    }
+
+    fn rotate_left(mut node: Box<RBNode>) -> Box<RBNode> {
+        let mut new_root = node
+            .right
+            .take()
+            .expect("rotate_left requires an existing right child");
+        node.right = new_root.left.take();
+        let original_color = node.color;
+        node.color = Color::Red;
+        new_root.color = original_color;
+        new_root.left = Some(node);
+        new_root
+    }
+
+    fn rotate_right(mut node: Box<RBNode>) -> Box<RBNode> {
+        let mut new_root = node
+            .left
+            .take()
+            .expect("rotate_right requires an existing left child");
+        node.left = new_root.right.take();
+        let original_color = node.color;
+        node.color = Color::Red;
+        new_root.color = original_color;
+        new_root.right = Some(node);
+        new_root
+    }
+
+    fn flip_colors(node: &mut Box<RBNode>) {
+        node.color = node.color.flipped();
+        if let Some(left) = node.left.as_mut() {
+            left.color = left.color.flipped();
+        }
+        if let Some(right) = node.right.as_mut() {
+            right.color = right.color.flipped();
+        }
+    }
+
+    fn left_left_is_red(node: &RBNode) -> bool {
+        match node.left.as_ref() {
+            Some(left) => RBNode::is_red(&left.left),
+            None => false,
+        }
+    }
+
+    fn insert_node(node: Option<Box<RBNode>>, key: u32) -> Box<RBNode> {
+        match node {
+            None => Box::new(RBNode::new(key, Color::Red)),
+            Some(mut current) => {
+                if key < current.key {
+                    current.left = Some(RBNode::insert_node(current.left.take(), key));
+                } else if key > current.key {
+                    current.right = Some(RBNode::insert_node(current.right.take(), key));
+                } else {
+                    current.key = key;
                 }
+
+                if RBNode::is_red(&current.right) && !RBNode::is_red(&current.left) {
+                    current = RBNode::rotate_left(current);
+                }
+
+                if RBNode::is_red(&current.left) && RBNode::left_left_is_red(&current) {
+                    current = RBNode::rotate_right(current);
+                }
+
+                if RBNode::is_red(&current.left) && RBNode::is_red(&current.right) {
+                    RBNode::flip_colors(&mut current);
+                }
+
+                current
             }
-        } else if key > self.key {
-            match &mut self.right {
-                Some(right) => right.insert(key),
-                None => {
-                    self.right = Some(Box::new(RBNode::new(key, Color::Red)));
+        }
+    }
+
+    fn validate_bst(node: &Option<Box<RBNode>>, min: Option<u32>, max: Option<u32>) -> bool {
+        match node {
+            None => true,
+            Some(current) => {
+                if let Some(lower) = min {
+                    if current.key <= lower {
+                        return false;
+                    }
                 }
+                if let Some(upper) = max {
+                    if current.key >= upper {
+                        return false;
+                    }
+                }
+
+                RBNode::validate_bst(&current.left, min, Some(current.key))
+                    && RBNode::validate_bst(&current.right, Some(current.key), max)
+            }
+        }
+    }
+
+    fn black_height(node: &Option<Box<RBNode>>) -> Option<usize> {
+        match node {
+            None => Some(1),
+            Some(current) => {
+                if current.color == Color::Red
+                    && (RBNode::is_red(&current.left) || RBNode::is_red(&current.right))
+                {
+                    return None;
+                }
+
+                let left_height = RBNode::black_height(&current.left)?;
+                let right_height = RBNode::black_height(&current.right)?;
+
+                if left_height != right_height {
+                    return None;
+                }
+
+                let black_increment = if current.color == Color::Black { 1 } else { 0 };
+                Some(left_height + black_increment)
             }
         }
     }
@@ -66,21 +177,31 @@ impl RBTree {
     }
 
     fn insert(&mut self, key: u32) {
-        match &mut self.root {
-            Some(root) => root.insert(key),
-            None => {
-                self.root = Some(Box::new(RBNode::new(key, Color::Black)));
+        self.root = Some(RBNode::insert_node(self.root.take(), key));
+        if let Some(root) = self.root.as_mut() {
+            root.color = Color::Black;
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        match self.root.as_ref() {
+            None => true,
+            Some(root) => {
+                root.color == Color::Black
+                    && RBNode::validate_bst(&self.root, None, None)
+                    && RBNode::black_height(&self.root).is_some()
             }
         }
     }
 }
 
 fn main() {
-    //
     let mut tree = RBTree::new();
-    tree.insert(5);
-    tree.insert(3);
-    tree.insert(7);
+    for key in [41, 38, 31, 12, 19, 8, 50, 60, 55, 54, 53] {
+        tree.insert(key);
+    }
+
+    assert!(tree.is_valid(), "red-black invariants should hold");
 
     diagram(&tree);
 }

--- a/src/bin/viz_server.rs
+++ b/src/bin/viz_server.rs
@@ -1,0 +1,120 @@
+use std::env;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process;
+
+fn main() {
+    let file_path = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/tmp/rust_viz_data.html".to_string());
+    let port = env::var("SPYTIAL_PORT")
+        .ok()
+        .and_then(|raw| raw.parse::<u16>().ok())
+        .unwrap_or(8080);
+
+    if !Path::new(&file_path).exists() {
+        eprintln!(
+            "Visualization file does not exist: {}. Run a diagram example first.",
+            file_path
+        );
+        process::exit(1);
+    }
+
+    let bind_addr = format!("0.0.0.0:{port}");
+    let listener = TcpListener::bind(&bind_addr).unwrap_or_else(|error| {
+        eprintln!("Failed to bind {}: {}", bind_addr, error);
+        process::exit(1);
+    });
+
+    println!("Visualization server ready at http://localhost:{port}/rust_viz_data.html");
+    println!("Health endpoint at http://localhost:{port}/health");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(mut stream) => handle_connection(&mut stream, &file_path),
+            Err(error) => eprintln!("Connection error: {}", error),
+        }
+    }
+}
+
+fn handle_connection(stream: &mut std::net::TcpStream, file_path: &str) {
+    let mut buffer = [0_u8; 4096];
+    let bytes_read = match stream.read(&mut buffer) {
+        Ok(0) => return,
+        Ok(read) => read,
+        Err(error) => {
+            eprintln!("Failed to read request: {}", error);
+            return;
+        }
+    };
+
+    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+    let mut parts = request
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace();
+
+    let method = parts.next().unwrap_or_default();
+    let raw_path = parts.next().unwrap_or("/");
+    let path = raw_path.split('?').next().unwrap_or(raw_path);
+
+    if method != "GET" {
+        write_response(
+            stream,
+            "405 Method Not Allowed",
+            "text/plain; charset=utf-8",
+            b"Method Not Allowed",
+        );
+        return;
+    }
+
+    match path {
+        "/" => {
+            let headers = "HTTP/1.1 302 Found\r\nLocation: /rust_viz_data.html\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            if let Err(error) = stream.write_all(headers.as_bytes()) {
+                eprintln!("Failed to write redirect response: {}", error);
+            }
+        }
+        "/health" => write_response(stream, "200 OK", "text/plain; charset=utf-8", b"ok"),
+        "/favicon.ico" => {
+            write_response(stream, "204 No Content", "text/plain; charset=utf-8", b"")
+        }
+        "/rust_viz_data.html" => match fs::read(file_path) {
+            Ok(contents) => write_response(stream, "200 OK", "text/html; charset=utf-8", &contents),
+            Err(error) => {
+                let body = format!("Failed to read visualization file: {}", error);
+                write_response(
+                    stream,
+                    "500 Internal Server Error",
+                    "text/plain; charset=utf-8",
+                    body.as_bytes(),
+                );
+            }
+        },
+        _ => write_response(
+            stream,
+            "404 Not Found",
+            "text/plain; charset=utf-8",
+            b"Not Found",
+        ),
+    }
+}
+
+fn write_response(stream: &mut std::net::TcpStream, status: &str, content_type: &str, body: &[u8]) {
+    let headers = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+
+    if let Err(error) = stream.write_all(headers.as_bytes()) {
+        eprintln!("Failed to write response headers: {}", error);
+        return;
+    }
+
+    if let Err(error) = stream.write_all(body) {
+        eprintln!("Failed to write response body: {}", error);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,15 @@ fn diagram_impl<T: Serialize>(value: &T, cnd_spec: &str) {
     let file_url = format!("file://{}", temp_file_path.display());
     println!("Opening visualization at: {}", file_url);
 
+    let skip_browser_open = env::var("SPYTIAL_NO_OPEN")
+        .map(|raw| matches!(raw.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false);
+
+    if skip_browser_open {
+        println!("SPYTIAL_NO_OPEN is set; skipping browser launch.");
+        return;
+    }
+
     #[cfg(target_os = "macos")]
     let open_cmd = "open";
     #[cfg(target_os = "windows")]
@@ -123,8 +132,11 @@ fn diagram_impl<T: Serialize>(value: &T, cnd_spec: &str) {
     #[cfg(target_os = "linux")]
     let open_cmd = "xdg-open";
 
-    Command::new(open_cmd)
-        .arg(&temp_file_path)
-        .spawn()
-        .expect("Failed to open browser");
+    if let Err(error) = Command::new(open_cmd).arg(&temp_file_path).spawn() {
+        eprintln!(
+            "Failed to open browser: {}. Open this file manually: {}",
+            error,
+            temp_file_path.display()
+        );
+    }
 }

--- a/templates/template.html
+++ b/templates/template.html
@@ -48,15 +48,6 @@
             flex: 1;
         }
         
-        .footer {
-            text-align: center;
-            padding: 6px;
-            background: #f8f9fa;
-            border-top: 1px solid #e1e5e9;
-            font-size: 11px;
-            color: #6a737d;
-        }
-        
         .reset-btn {
             background: #0366d6;
             color: white;
@@ -89,9 +80,6 @@
             </webcola-cnd-graph>
         </div>
         
-        <div class="footer">
-            <span>Powered by Cope and Drag</span>
-        </div>
     </div>
     
     <div id="error-message"></div>


### PR DESCRIPTION
Summary
- replace the old examples/rbt.rs BST-style insertion sample with an insertion-balanced LLRB red-black tree example and invariant checks
- add headless diagram mode via SPYTIAL_NO_OPEN so container runs do not try to launch a GUI
- add Docker runtime support that runs an example, then serves /tmp/rust_viz_data.html over HTTP on port 8080 with a /health endpoint
- document the new Docker UX and refresh example guidance in README and USER_GUIDE
- remove the template footer text Powered by Cope and Drag

Verification
- cargo fmt
- cargo test --lib --tests
- docker build -t caraspace-local .
- docker run --rm -p 8080:8080 caraspace-local then verify /health and /rust_viz_data.html
