### PR TITLE
Stop printing specs to stdout and trim docs wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ macros/
 ### Core Functions
 
 - `diagram<T>(value: &T)` - Create visualization with automatic decorator collection
-- `diagram_with_spec<T>(value: &T, cnd_spec: &str)` - Create visualization with custom SpyTial spec (sort of an escape hatch)
+- `diagram_with_spec<T>(value: &T, spec: &str)` - Create visualization with a custom SpyTial spec (escape hatch)
 - `export_json_instance<T>(value: &T)` - Export Rust data to the relational JSON format used by Spytial
 
 ### Decorator Attributes
@@ -71,7 +71,7 @@ The compile-time analysis supports:
 - `cargo run --example demo` shows decorator collection on nested business-domain structs.
 - `cargo run --example rbt` builds an insertion-balanced red-black tree (LLRB style) and renders it with node color/layout decorators.
 
-## 🛠 Development
+## Development
 
 ```bash
 cargo test --lib --tests

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -21,8 +21,6 @@ json_data_instance_export = { path = "/path/to/caraspace" }
 serde = { version = "1", features = ["derive"] }
 ```
 
-If you are consuming a published version later, replace the `path` dependency with the crate version.
-
 ## Quick Start
 
 ```rust
@@ -181,7 +179,7 @@ After the example runs, the container serves the generated visualization at `htt
 
 ## Limitations and Expectations
 
-- The browser rendering path relies on the embedded HTML template and CDN-hosted `spytial-core`.
+- The browser rendering path relies on the embedded HTML template and bundled browser dependencies.
 - Compile-time type walking is intentionally conservative; it handles common wrappers, not arbitrary type-level programming.
 - The crate name and repository name do not currently match. In Cargo code samples, use `json_data_instance_export`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ use std::process::Command;
 /// diagram(&company);  // Shows decorators from both Company AND Person
 /// ```
 pub fn diagram<T: spytial_annotations::HasSpytialDecorators + Serialize>(value: &T) {
-    let cnd_spec = collect_cnd_spec_for_diagram(value);
-    diagram_impl(value, &cnd_spec);
+    let spytial_spec = collect_spytial_spec_for_diagram(value);
+    diagram_impl(value, &spytial_spec);
 }
 
 /// Collect SpyTial specification using compile-time decorator collection.
@@ -66,37 +66,27 @@ pub fn diagram<T: spytial_annotations::HasSpytialDecorators + Serialize>(value: 
 /// With the new compile-time system, calling `T::decorators()` returns decorators
 /// from the type itself AND all nested types that have decorators. This eliminates
 /// the need for complex runtime type discovery and registration.
-fn collect_cnd_spec_for_diagram<T: spytial_annotations::HasSpytialDecorators + Serialize>(
+fn collect_spytial_spec_for_diagram<T: spytial_annotations::HasSpytialDecorators + Serialize>(
     _value: &T,
 ) -> String {
-    println!("🔍 Assembling SpyTial spec with compile-time decorator collection...");
-
     // The magic happens here: T::decorators() includes ALL decorators
     // from this type AND all nested decorated types (analyzed at compile time)
     let all_decorators = T::decorators();
-    println!(
-        "   ✨ Compile-time collected decorators: {} constraints, {} directives",
-        all_decorators.constraints.len(),
-        all_decorators.directives.len()
-    );
 
     // Serialize to YAML
-    let cnd_spec = spytial_annotations::to_yaml(&all_decorators).unwrap_or_default();
-    println!("   📋 Generated SpyTial spec:\n{}", cnd_spec);
-
-    cnd_spec
+    spytial_annotations::to_yaml(&all_decorators).unwrap_or_default()
 }
 
 /// Creates a diagram with a custom SpyTial specification (legacy function).
 ///
 /// This allows you to provide a custom SpyTial specification instead of using
 /// the automatic compile-time decorator collection.
-pub fn diagram_with_spec<T: Serialize>(value: &T, cnd_spec: &str) {
-    diagram_impl(value, cnd_spec);
+pub fn diagram_with_spec<T: Serialize>(value: &T, spec: &str) {
+    diagram_impl(value, spec);
 }
 
 /// Internal implementation shared by diagram functions.
-fn diagram_impl<T: Serialize>(value: &T, cnd_spec: &str) {
+fn diagram_impl<T: Serialize>(value: &T, spec: &str) {
     // Export the struct to our custom JSON format with type information
     let json_instance = export_json_instance(value);
     let json_data = serde_json::to_string_pretty(&json_instance).unwrap();
@@ -105,23 +95,18 @@ fn diagram_impl<T: Serialize>(value: &T, cnd_spec: &str) {
     let template = include_str!("../templates/template.html");
     let rendered_html = template
         .replace("{{ json_data }}", &json_data)
-        .replace("{{ cnd_spec }}", cnd_spec);
+        .replace("{{ spytial_spec }}", spec);
 
     // Save the rendered HTML to a temporary file
     let temp_dir = env::temp_dir();
     let temp_file_path = temp_dir.join("rust_viz_data.html");
     fs::write(&temp_file_path, rendered_html).expect("Failed to write HTML to file");
 
-    // Open the HTML file in the browser
-    let file_url = format!("file://{}", temp_file_path.display());
-    println!("Opening visualization at: {}", file_url);
-
     let skip_browser_open = env::var("SPYTIAL_NO_OPEN")
         .map(|raw| matches!(raw.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
         .unwrap_or(false);
 
     if skip_browser_open {
-        println!("SPYTIAL_NO_OPEN is set; skipping browser launch.");
         return;
     }
 

--- a/templates/template.html
+++ b/templates/template.html
@@ -87,7 +87,7 @@
 
     <script>
         // Embedded data passed from Rust (using simple string replacement)
-        const cndSpec = `{{ cnd_spec }}`;
+        const spytialSpec = `{{ spytial_spec }}`;
         
         const jsonData = `{{ json_data }}`;
 
@@ -127,8 +127,8 @@
 
             // Check if Core is available
             if (typeof CndCore === 'undefined') {
-                console.error('CnD Core library is not available');
-                showError('CnD Core library failed to load. The visualization cannot be displayed.');
+                console.error('Spytial core library is not available');
+                showError('Spytial core library failed to load. The visualization cannot be displayed.');
                 return;
             }
 
@@ -161,8 +161,8 @@
 
                 window.evaluator = sgqEvaluator; // Expose evaluator for debugging
 
-                // Parse the CND specification (empty specs are valid)
-                const layoutSpec = CndCore.parseLayoutSpec(cndSpec);
+                // Parse the layout specification (empty specs are valid)
+                const layoutSpec = CndCore.parseLayoutSpec(spytialSpec);
                 console.log('Layout spec parsed');
 
                 // Generate the layout


### PR DESCRIPTION
## Summary
- stop printing generated spec and browser-open skip messages from the library path
- rename internal placeholder and variable names from cnd_spec to spec or spytial_spec
- remove CnD wording from browser error text
- simplify docs by removing publish or CDN mentions and emoji heading

## Verification
- cargo test
- SPYTIAL_NO_OPEN=1 cargo run --example demo