### PR TITLE
Implement TagDirective (#37)

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -119,6 +119,7 @@ These map onto the Rust builder and YAML serialization layer in `spytial_annotat
 | `#[hide_field(field = "...")]` | Hide a relation |
 | `#[hide_atom(selector = "...")]` | Hide selected atoms |
 | `#[inferred_edge(name = "...", selector = "...")]` | Add inferred edges |
+| `#[tag(to_tag = "...", name = "...", value = "...")]` | Tag matching atoms with computed attribute |
 
 ## Compile-Time Behavior
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -141,7 +141,8 @@ fn generate_probe_call(type_name: &str) -> proc_macro2::TokenStream {
 /// - `#[hide_field(field = "field")]` - Adds hide field directive
 /// - `#[hide_atom(selector = "sel")]` - Adds hide atom directive
 /// - `#[inferred_edge(name = "edge", selector = "sel")]` - Adds inferred edge directive
-/// 
+/// - `#[tag(to_tag = "sel", name = "attr", value = "n-ary selector")]` - Adds tag directive
+///
 /// # Example
 /// ```rust
 /// use serde::Serialize;
@@ -155,7 +156,7 @@ fn generate_probe_call(type_name: &str) -> proc_macro2::TokenStream {
 ///     age: u32,
 /// }
 /// ```
-#[proc_macro_derive(SpytialDecorators, attributes(attribute, flag, orientation, align, cyclic, group, atom_color, size, icon, edge_color, projection, hide_field, hide_atom, inferred_edge))]
+#[proc_macro_derive(SpytialDecorators, attributes(attribute, flag, orientation, align, cyclic, group, atom_color, size, icon, edge_color, projection, hide_field, hide_atom, inferred_edge, tag))]
 pub fn derive_spytial_decorators(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     
@@ -251,6 +252,11 @@ pub fn derive_spytial_decorators(input: TokenStream) -> TokenStream {
                     .inferred_edge(#name, #selector)
                 });
             }
+            Some(SpatialAttribute::Tag { to_tag, name, value }) => {
+                decorator_calls.push(quote! {
+                    .tag(#to_tag, #name, #value)
+                });
+            }
             None => {}
         }
     }
@@ -308,6 +314,7 @@ enum SpatialAttribute {
     HideField { field: String, selector: Option<String> },
     HideAtom { selector: String },
     InferredEdge { name: String, selector: String },
+    Tag { to_tag: String, name: String, value: String },
 }
 
 fn parse_spatial_attribute(attr: &Attribute) -> Option<SpatialAttribute> {
@@ -341,6 +348,8 @@ fn parse_spatial_attribute(attr: &Attribute) -> Option<SpatialAttribute> {
         parse_hide_atom_args(attr)
     } else if path.is_ident("inferred_edge") {
         parse_inferred_edge_args(attr)
+    } else if path.is_ident("tag") {
+        parse_tag_args(attr)
     } else {
         None
     }
@@ -543,11 +552,26 @@ fn parse_inferred_edge_args(attr: &Attribute) -> Option<SpatialAttribute> {
     if let Ok(meta) = attr.meta.require_list() {
         let tokens = &meta.tokens;
         let token_str = tokens.to_string();
-        
+
         let name = extract_string_from_tokens(&token_str, "name").unwrap_or_else(|| "edge".to_string());
         let selector = extract_string_from_tokens(&token_str, "selector").unwrap_or_else(|| "".to_string());
-        
+
         Some(SpatialAttribute::InferredEdge { name, selector })
+    } else {
+        None
+    }
+}
+
+fn parse_tag_args(attr: &Attribute) -> Option<SpatialAttribute> {
+    if let Ok(meta) = attr.meta.require_list() {
+        let tokens = &meta.tokens;
+        let token_str = tokens.to_string();
+
+        let to_tag = extract_string_from_tokens(&token_str, "to_tag").unwrap_or_default();
+        let name = extract_string_from_tokens(&token_str, "name").unwrap_or_default();
+        let value = extract_string_from_tokens(&token_str, "value").unwrap_or_default();
+
+        Some(SpatialAttribute::Tag { to_tag, name, value })
     } else {
         None
     }

--- a/src/spytial_annotations/runtime.rs
+++ b/src/spytial_annotations/runtime.rs
@@ -42,6 +42,7 @@ pub enum Directive {
     HideField(HideFieldDirective),
     HideAtom(HideAtomDirective),
     InferredEdge(InferredEdgeDirective),
+    Tag(TagDirective),
     Flag(FlagDirective),
 }
 
@@ -210,6 +211,30 @@ pub struct InferredEdgeDirective {
 pub struct InferredEdgeParams {
     pub name: String,
     pub selector: String,
+}
+
+/// `TagDirective` adds computed attributes to nodes based on n-ary selector
+/// evaluation. Mirrors `TagDirective` in `spytial-core`'s
+/// `src/layout/layoutspec.ts` — the canonical YAML form is:
+///
+/// ```yaml
+/// directives:
+///   - tag:
+///       toTag: 'Person'
+///       name: 'status'
+///       value: 'Person.status'
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TagDirective {
+    pub tag: TagParams,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TagParams {
+    #[serde(rename = "toTag")]
+    pub to_tag: String,
+    pub name: String,
+    pub value: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -465,6 +490,17 @@ impl SpytialDecoratorsBuilder {
     pub fn flag(mut self, name: &str) -> Self {
         self.directives.push(Directive::Flag(FlagDirective {
             flag: name.to_string(),
+        }));
+        self
+    }
+
+    pub fn tag(mut self, to_tag: &str, name: &str, value: &str) -> Self {
+        self.directives.push(Directive::Tag(TagDirective {
+            tag: TagParams {
+                to_tag: to_tag.to_string(),
+                name: name.to_string(),
+                value: value.to_string(),
+            },
         }));
         self
     }

--- a/tests/decorators.rs
+++ b/tests/decorators.rs
@@ -35,3 +35,59 @@ fn derive_macro_emits_align_and_existing_decorators() {
     assert!(yaml.contains("orientation:"));
     assert!(yaml.contains("flag: important"));
 }
+
+#[derive(Serialize, SpytialDecorators)]
+#[tag(to_tag = "Person", name = "status", value = "Person.status")]
+struct TaggedPerson {
+    name: String,
+    status: String,
+}
+
+#[test]
+fn tag_directive_single() {
+    let decorators = TaggedPerson::decorators();
+
+    let tag = decorators
+        .directives
+        .iter()
+        .find_map(|d| match d {
+            Directive::Tag(t) => Some(t),
+            _ => None,
+        })
+        .expect("expected a Tag directive");
+
+    assert_eq!(tag.tag.to_tag, "Person");
+    assert_eq!(tag.tag.name, "status");
+    assert_eq!(tag.tag.value, "Person.status");
+
+    let yaml = to_yaml(&decorators).unwrap();
+    assert!(yaml.contains("tag:"));
+    assert!(yaml.contains("toTag: Person"));
+    assert!(yaml.contains("name: status"));
+    assert!(yaml.contains("value: Person.status"));
+}
+
+#[derive(Serialize, SpytialDecorators)]
+#[tag(to_tag = "Person", name = "age", value = "Person.age")]
+#[tag(to_tag = "Car", name = "owner", value = "Car.ownedBy")]
+struct MultiTagged {
+    id: u32,
+}
+
+#[test]
+fn tag_directive_multiple() {
+    let decorators = MultiTagged::decorators();
+
+    let tags: Vec<_> = decorators
+        .directives
+        .iter()
+        .filter_map(|d| match d {
+            Directive::Tag(t) => Some(&t.tag),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(tags.len(), 2);
+    assert!(tags.iter().any(|t| t.to_tag == "Person" && t.name == "age"));
+    assert!(tags.iter().any(|t| t.to_tag == "Car" && t.name == "owner"));
+}


### PR DESCRIPTION
## Summary

- Add `Directive::Tag(TagDirective { tag: TagParams { to_tag, name, value } })` with `#[serde(rename = "toTag")]` so the wire format matches spytial-core's canonical form.
- Add `#[tag(to_tag = "...", name = "...", value = "...")]` derive-macro attribute, plumbed through `SpatialAttribute::Tag` and a `SpytialDecoratorsBuilder::tag(...)` method.
- Document the new attribute in `USER_GUIDE.md`.

The emitted YAML matches the form spytial-core's parser expects (`tests/tag-directive.test.ts` in core):

```yaml
directives:
  - tag:
      toTag: 'Person'
      name: 'status'
      value: 'Person.status'
```

Closes #37.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 33 passed (8 lib + 3 decorators incl. 2 new + 21 export + 1 doctest), 0 failed
- [x] New tests `tag_directive_single` and `tag_directive_multiple` cover the happy path, the YAML output (`toTag: ...`, `name: ...`, `value: ...`), and multiple `#[tag]` attributes on the same struct
- [x] Confirmed no new clippy/fmt issues introduced beyond the pre-existing ones tracked in #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)