### PR TITLE
Add `caraspace::dbg!` as strict superset of `std::dbg!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 # CaraSpace
 
-**Spytial for Rust — diagrams instead of `{:#?}` output.**
+**`dbg!` for shapes, not just text.**
 
-You already write `dbg!(tree)` and squint at 200 lines of nested debug
-output. Swap one line and you also get a real diagram in your browser.
-`caraspace::dbg!` is a strict superset of `std::dbg!` — same stderr
-output, same return semantics, plus the picture.
+`caraspace::dbg!` is a drop-in replacement for `std::dbg!` that opens an
+interactive diagram of the value alongside the usual stderr trail. Same
+calling convention, same `{:#?}` output, plus the picture.
 
 ```rust
-use caraspace::dbg; // shadows std::dbg!
+use caraspace::dbg;
 
 let tree = build_red_black_tree();
-let tree = dbg!(tree); // stderr trail + browser tab; `tree` flows through
+let tree = dbg!(tree);
 ```
 
-The structure was already in your types. Rust's `derive` macros, the
-borrow checker, even your `Debug` impl all know what nodes and edges
-live inside your value — caraspace refines that into a faithful picture.
-For the longer version of the argument, see
+stderr:
+
+```text
+[src/main.rs:42:17] tree = RBTree {
+    root: Some(RBNode { key: 38, color: Black, left: Some(RBNode { ... }), ... }),
+}
+```
+
+Browser: an interactive diagram of the same tree.
+
+The structure was already in your types — `#[derive(Debug)]` is proof that
+Rust knows how to walk your value. Caraspace refines that into a faithful
+picture instead of nested text. For the longer argument, see
 [Spytial on Brown PLT's blog](https://blog.brownplt.org/2026/05/22/spytial.html).
 
 ## Install
@@ -28,7 +36,30 @@ caraspace = "0.1"
 serde = { version = "1", features = ["derive"] }
 ```
 
-## 30-second example
+## The swap
+
+```diff
+- std::dbg!(tree)
++ caraspace::dbg!(tree)
+```
+
+Or shadow it for the whole module:
+
+```rust
+use caraspace::dbg;
+```
+
+The calling convention matches `std::dbg!` exactly:
+
+| Form         | Behavior                                                          |
+|--------------|-------------------------------------------------------------------|
+| `dbg!()`     | Prints location to stderr (same as `std::dbg!()`)                 |
+| `dbg!(x)`    | Prints `{:#?}` + opens diagram, returns `x` through               |
+| `dbg!(&x)`   | Same, borrows                                                     |
+| `dbg!(a, b)` | Returns `(a, b)`; one diagram tab per argument                    |
+
+Type requirements: `Debug` (already required by `std::dbg!`), plus `Serialize`
+and `SpytialDecorators`:
 
 ```rust
 use caraspace::{dbg, SpytialDecorators};
@@ -41,70 +72,21 @@ struct Node {
     left: Option<Box<Node>>,
     right: Option<Box<Node>>,
 }
-
-fn main() {
-    let tree = Node {
-        key: 5,
-        left: Some(Box::new(Node { key: 3, left: None, right: None })),
-        right: Some(Box::new(Node { key: 7, left: None, right: None })),
-    };
-    dbg!(tree);
-}
 ```
 
-Derive `Debug`, `Serialize`, `SpytialDecorators`, drop in `dbg!`, run.
-That's the whole story for the simple case.
+That's the whole setup. `SPYTIAL_NO_OPEN=1` suppresses browser launch (CI,
+tests, headless runs) — stderr is unaffected, so `cargo test` capture behaves
+exactly like it does for `std::dbg!`.
 
-## Drop-in for `std::dbg!`
+## When you want more than the default layout
 
-`caraspace::dbg!` is a strict superset of `std::dbg!` — same calling
-convention, same return semantics, plus a diagram. The migration is
-literally one line:
-
-```diff
-- std::dbg!(tree)
-+ caraspace::dbg!(tree)
-```
-
-or, with a `use`:
+Caraspace decorators (`#[attribute]`, `#[align]`, `#[orientation]`,
+`#[atom_color]`, …) tell the diagrammer what to emphasise — relative
+position, color, alignment, grouping. They're declarative constraints, not
+imperative rendering code:
 
 ```rust
-use caraspace::dbg; // shadows std::dbg! for the rest of the module
-```
-
-| Form               | Behavior                                          |
-|--------------------|---------------------------------------------------|
-| `dbg!()`           | Prints location to stderr (same as `std::dbg!()`) |
-| `dbg!(x)`          | Prints `[file:line] x = {:#?}` + opens diagram, returns `x` |
-| `dbg!(&x)`         | Same, borrows                                     |
-| `dbg!(a, b)`       | Returns `(a, b)`, opens one tab per argument      |
-
-Requirements on the value's type: `Debug` (same as `std::dbg!`), plus
-`Serialize` and `SpytialDecorators` for caraspace.
-
-Coexists fine with `std::dbg!` (different namespace). Honor
-`SPYTIAL_NO_OPEN=1` to suppress browser launch in tests, CI, or any
-headless context — stderr behavior is unchanged so `assert!`-style test
-flows still work.
-
-## The two ways in
-
-- **`dbg!(value)`** — printf-style, one-character swap from `std::dbg!`,
-  prints to stderr *and* opens a browser tab. Returns the value through
-  so it composes inside larger expressions.
-- **`diagram(&value)`** — the explicit function form. No stderr output,
-  no source location, doesn't take ownership.
-
-Both pick up decorators attached to the type and its nested types.
-
-## Telling the diagrammer what you want
-
-Caraspace's decorators (`#[attribute]`, `#[align]`, `#[orientation]`,
-`#[atom_color]`, …) specify layout *declaratively* on the type, not the
-value. The diagrammer treats them as constraints:
-
-```rust
-#[derive(Serialize, SpytialDecorators)]
+#[derive(Debug, Serialize, SpytialDecorators)]
 #[attribute(field = "key")]
 #[attribute(field = "color")]
 #[orientation(selector = "{x, y : RBNode | x->y in left}",  directions = ["left",  "below"])]
@@ -114,52 +96,52 @@ value. The diagrammer treats them as constraints:
 struct RBNode { /* ... */ }
 ```
 
-The full red-black-tree demo is in [`examples/rbt.rs`](./examples/rbt.rs):
+Decorators are collected from nested types automatically — decorating
+`Person` once is enough for those decorators to apply wherever `Person`
+appears inside another decorated type. `Vec<T>`, `Option<T>`, `Box<T>`, and
+their nested combinations all unwrap during the compile-time walk.
 
-```bash
-cargo run --example rbt
+Full attribute reference: [USER_GUIDE.md](./USER_GUIDE.md).
+
+## Without `dbg!`
+
+For library code, or anywhere you don't want stderr noise, call `diagram`
+directly:
+
+```rust
+use caraspace::diagram;
+diagram(&tree); // no stderr line, no source location, doesn't move
 ```
-
-See [USER_GUIDE.md](./USER_GUIDE.md) for the complete decorator reference.
-
-## How the derive walks your types
-
-`#[derive(SpytialDecorators)]` analyses the type tree at compile time and
-includes decorators from nested types automatically:
-
-- `Vec<T>`, `Option<T>`, `Box<T>` → unwraps to `T`
-- Nested combinations like `Vec<Option<Box<T>>>` work the same way
-- Direct types are analysed in place
-
-Decorating `Person` once is enough for those decorators to show up
-wherever `Person` appears inside another decorated type. No manual
-registration.
 
 ## Examples
 
-- `cargo run --example dbg_basic` — the smallest `dbg!` swap, runnable
-- `cargo run --example demo` — decorator collection on nested structs
-- `cargo run --example rbt` — insertion-balanced red-black tree with
-  color and layout decorators
+| Example       | What it shows                                          |
+|---------------|--------------------------------------------------------|
+| `dbg_basic`   | The smallest `dbg!` swap                               |
+| `demo`        | Decorator collection across nested structs             |
+| `rbt`         | Insertion-balanced red-black tree with layout + colors |
+
+```bash
+cargo run --example dbg_basic
+cargo run --example rbt
+```
 
 ## Headless / Docker
 
 ```bash
 docker build -t caraspace .
 docker run --rm -p 8080:8080 caraspace          # default: rbt
-docker run --rm -p 8080:8080 caraspace demo     # any other example
+docker run --rm -p 8080:8080 caraspace demo
 ```
 
-Open `http://localhost:8080/rust_viz_data.html`. Browser launch is
-disabled inside the container (`SPYTIAL_NO_OPEN=1`).
+Open `http://localhost:8080/rust_viz_data.html`. Browser launch is disabled
+inside the container (`SPYTIAL_NO_OPEN=1`).
 
-## Documentation
+## Docs
 
-- [USER_GUIDE.md](./USER_GUIDE.md) — installation, decorator reference,
-  common workflows
+- [USER_GUIDE.md](./USER_GUIDE.md) — full decorator reference, common workflows
 - [doc.md](./doc.md) — compile-time analysis internals
-- [Spytial blog post](https://blog.brownplt.org/2026/05/22/spytial.html)
-  — the design philosophy
+- [Spytial blog post](https://blog.brownplt.org/2026/05/22/spytial.html) — design philosophy
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,120 +1,174 @@
 # CaraSpace
 
-Spytial for Rust.
+**Spytial for Rust — diagrams instead of `{:#?}` output.**
 
-The crate is published as `caraspace`.
+You already write `dbg!(tree)` and squint at 200 lines of nested debug
+output. Swap one line and you also get a real diagram in your browser.
+`caraspace::dbg!` is a strict superset of `std::dbg!` — same stderr
+output, same return semantics, plus the picture.
+
+```rust
+use caraspace::dbg; // shadows std::dbg!
+
+let tree = build_red_black_tree();
+let tree = dbg!(tree); // stderr trail + browser tab; `tree` flows through
+```
+
+The structure was already in your types. Rust's `derive` macros, the
+borrow checker, even your `Debug` impl all know what nodes and edges
+live inside your value — caraspace refines that into a faithful picture.
+For the longer version of the argument, see
+[Spytial on Brown PLT's blog](https://blog.brownplt.org/2026/05/22/spytial.html).
+
+## Install
+
+```toml
+[dependencies]
+caraspace = "0.1"
+serde = { version = "1", features = ["derive"] }
+```
+
+## 30-second example
+
+```rust
+use caraspace::{dbg, SpytialDecorators};
+use serde::Serialize;
+
+#[derive(Debug, Serialize, SpytialDecorators)]
+#[attribute(field = "key")]
+struct Node {
+    key: u32,
+    left: Option<Box<Node>>,
+    right: Option<Box<Node>>,
+}
+
+fn main() {
+    let tree = Node {
+        key: 5,
+        left: Some(Box::new(Node { key: 3, left: None, right: None })),
+        right: Some(Box::new(Node { key: 7, left: None, right: None })),
+    };
+    dbg!(tree);
+}
+```
+
+Derive `Debug`, `Serialize`, `SpytialDecorators`, drop in `dbg!`, run.
+That's the whole story for the simple case.
+
+## Drop-in for `std::dbg!`
+
+`caraspace::dbg!` is a strict superset of `std::dbg!` — same calling
+convention, same return semantics, plus a diagram. The migration is
+literally one line:
+
+```diff
+- std::dbg!(tree)
++ caraspace::dbg!(tree)
+```
+
+or, with a `use`:
+
+```rust
+use caraspace::dbg; // shadows std::dbg! for the rest of the module
+```
+
+| Form               | Behavior                                          |
+|--------------------|---------------------------------------------------|
+| `dbg!()`           | Prints location to stderr (same as `std::dbg!()`) |
+| `dbg!(x)`          | Prints `[file:line] x = {:#?}` + opens diagram, returns `x` |
+| `dbg!(&x)`         | Same, borrows                                     |
+| `dbg!(a, b)`       | Returns `(a, b)`, opens one tab per argument      |
+
+Requirements on the value's type: `Debug` (same as `std::dbg!`), plus
+`Serialize` and `SpytialDecorators` for caraspace.
+
+Coexists fine with `std::dbg!` (different namespace). Honor
+`SPYTIAL_NO_OPEN=1` to suppress browser launch in tests, CI, or any
+headless context — stderr behavior is unchanged so `assert!`-style test
+flows still work.
+
+## The two ways in
+
+- **`dbg!(value)`** — printf-style, one-character swap from `std::dbg!`,
+  prints to stderr *and* opens a browser tab. Returns the value through
+  so it composes inside larger expressions.
+- **`diagram(&value)`** — the explicit function form. No stderr output,
+  no source location, doesn't take ownership.
+
+Both pick up decorators attached to the type and its nested types.
+
+## Telling the diagrammer what you want
+
+Caraspace's decorators (`#[attribute]`, `#[align]`, `#[orientation]`,
+`#[atom_color]`, …) specify layout *declaratively* on the type, not the
+value. The diagrammer treats them as constraints:
+
+```rust
+#[derive(Serialize, SpytialDecorators)]
+#[attribute(field = "key")]
+#[attribute(field = "color")]
+#[orientation(selector = "{x, y : RBNode | x->y in left}",  directions = ["left",  "below"])]
+#[orientation(selector = "{x, y : RBNode | x->y in right}", directions = ["right", "below"])]
+#[atom_color(selector = "{x : RBNode | @:(x.color) = Red}",   value = "red")]
+#[atom_color(selector = "{x : RBNode | @:(x.color) = Black}", value = "black")]
+struct RBNode { /* ... */ }
+```
+
+The full red-black-tree demo is in [`examples/rbt.rs`](./examples/rbt.rs):
+
+```bash
+cargo run --example rbt
+```
+
+See [USER_GUIDE.md](./USER_GUIDE.md) for the complete decorator reference.
+
+## How the derive walks your types
+
+`#[derive(SpytialDecorators)]` analyses the type tree at compile time and
+includes decorators from nested types automatically:
+
+- `Vec<T>`, `Option<T>`, `Box<T>` → unwraps to `T`
+- Nested combinations like `Vec<Option<Box<T>>>` work the same way
+- Direct types are analysed in place
+
+Decorating `Person` once is enough for those decorators to show up
+wherever `Person` appears inside another decorated type. No manual
+registration.
+
+## Examples
+
+- `cargo run --example dbg_basic` — the smallest `dbg!` swap, runnable
+- `cargo run --example demo` — decorator collection on nested structs
+- `cargo run --example rbt` — insertion-balanced red-black tree with
+  color and layout decorators
+
+## Headless / Docker
+
+```bash
+docker build -t caraspace .
+docker run --rm -p 8080:8080 caraspace          # default: rbt
+docker run --rm -p 8080:8080 caraspace demo     # any other example
+```
+
+Open `http://localhost:8080/rust_viz_data.html`. Browser launch is
+disabled inside the container (`SPYTIAL_NO_OPEN=1`).
 
 ## Documentation
 
-- [User Guide](./USER_GUIDE.md) for installation, quick start, and common workflows
-- [Design Notes](./doc.md) for the compile-time and serialization internals
-
-## How Compile-Time Annotation Collection Works
-
-Uses **procedural macro analysis** to walk the entire type tree at compile time:
-
-1. **Field Analysis**: The `SpytialDecorators` derive macro analyzes all fields in your struct
-2. **Type Tree Walking**: For each field, it recursively analyzes the type:
-   - `Vec<T>` → analyzes `T`
-   - `Option<T>` → analyzes `T` 
-   - `Box<T>` → analyzes `T`
-   - Direct types → analyzes the type itself
-3. **Decorator Collection**: For each discovered type that implements `HasSpytialDecorators`, it generates code to include those decorators
-
-## Library Structure
-
-```
-src/
-├── lib.rs                    # Main API with cleaned up functions
-├── export.rs                 # JSON serialization with type information
-├── jsondata.rs               # Custom JSON data structures
-└── spytial_annotations/
-    ├── mod.rs                # SpyTial decorator system
-    └── runtime.rs            # Runtime builder with compile-time support
-
-macros/
-└── src/
-    └── lib.rs                # Compile-time type analysis procedural macro
-```
-
-## API Reference
-
-### Core Functions
-
-- `diagram<T>(value: &T)` - Create visualization with automatic decorator collection
-- `diagram_with_spec<T>(value: &T, spec: &str)` - Create visualization with a custom SpyTial spec (escape hatch)
-- `export_json_instance<T>(value: &T)` - Export Rust data to the relational JSON format used by Spytial
-
-### Decorator Attributes
-
-- `#[attribute(field = "field_name")]` - Mark a field as an attribute
-- `#[flag(name = "flag_name")]` - Add a boolean flag
-- `#[orientation(selector = "...", directions = [...])]` - Relative positioning constraint
-- `#[align(selector = "...", direction = "...")]` - Horizontal or vertical alignment
-- `#[cyclic(selector = "...", direction = "...")]` - Cyclic ordering constraint
-- `#[group(...)]` - Grouping constraint
-- Visual directives such as `#[atom_color(...)]`, `#[size(...)]`, `#[icon(...)]`, `#[hide_atom(...)]`
-
-### Supported Field Types
-
-The compile-time analysis supports:
-- Direct types: `Person`, `MyStruct`
-- Collections: `Vec<T>`, `Vec<Box<T>>`
-- Options: `Option<T>`, `Option<Box<T>>`
-- Boxed types: `Box<T>`
-- Nested combinations: `Vec<Option<Box<Person>>>`
-
-
-
-## Representative Examples
-
-- `cargo run --example demo` shows decorator collection on nested business-domain structs.
-- `cargo run --example rbt` builds an insertion-balanced red-black tree (LLRB style) and renders it with node color/layout decorators.
+- [USER_GUIDE.md](./USER_GUIDE.md) — installation, decorator reference,
+  common workflows
+- [doc.md](./doc.md) — compile-time analysis internals
+- [Spytial blog post](https://blog.brownplt.org/2026/05/22/spytial.html)
+  — the design philosophy
 
 ## Development
 
 ```bash
 cargo test --lib --tests
 cargo test --doc
-cargo run --example demo
 cargo run --example rbt
 ```
 
-## Docker
-
-Build the image:
-
-```bash
-docker build -t caraspace .
-```
-
-Run the default red-black tree example:
-
-```bash
-docker run --rm -p 8080:8080 caraspace
-```
-
-Run a different example:
-
-```bash
-docker run --rm -p 8080:8080 caraspace demo
-```
-
-When the example finishes, the container starts a small HTTP server and logs:
-
-`Visualization server ready at http://localhost:8080/rust_viz_data.html`
-
-Open that URL in your host browser. Browser launch inside the container stays disabled (`SPYTIAL_NO_OPEN=1`).
-
-
 ## License
 
-Licensed under either of Apache License, Version 2.0 or MIT license at your option.
-
-
-## Data Dup
-
-The Rust mental model we're following:
-
-Zero-sized types → Singletons (they have no data, only type/variant identity)
-Types with data → Multiple atoms (each occurrence is a distinct value)
+MIT or Apache-2.0, at your option.

--- a/README.md
+++ b/README.md
@@ -1,65 +1,41 @@
 # CaraSpace
 
-**`dbg!` for shapes, not just text.**
-
-`caraspace::dbg!` is a drop-in replacement for `std::dbg!` that opens an
-interactive diagram of the value alongside the usual stderr trail. Same
-calling convention, same `{:#?}` output, plus the picture.
-
-```rust
-use caraspace::dbg;
-
-let tree = build_red_black_tree();
-let tree = dbg!(tree);
-```
-
-stderr:
+You can prove memory safety at compile time. You can derive `Hash`, `Ord`,
+and `Serialize` from a single line. You can run a million-row benchmark
+while the GC-language people are still writing config. And yet, when you
+want to know the shape of the `BTreeMap<NodeId, Vec<Edge>>` your program
+just built, you reach for `dbg!` and start counting braces.
 
 ```text
 [src/main.rs:42:17] tree = RBTree {
-    root: Some(RBNode { key: 38, color: Black, left: Some(RBNode { ... }), ... }),
-}
+    root: Some(
+        RBNode { key: 38, color: Black, left: Some(RBNode { key: 19,
+        color: Black, left: Some(RBNode { key: 12, color: Black, left:
+        Some(RBNode { key: 8, color: Red, left: None, right: None }),
+        right: None }), right: Some(RBNode { key: 31, color: Red, ...
 ```
 
-Browser: an interactive diagram of the same tree.
+You know what this *is*. You'd sketch it on paper in five seconds. The
+terminal won't.
 
-The structure was already in your types — `#[derive(Debug)]` is proof that
-Rust knows how to walk your value. Caraspace refines that into a faithful
-picture instead of nested text. For the longer argument, see
-[Spytial on Brown PLT's blog](https://blog.brownplt.org/2026/05/22/spytial.html).
+## The tree was already in the `derive(Debug)`
 
-## Install
+`#[derive(Debug)]` is proof that Rust already knows how to walk your value.
+Structs become records. Fields become edges. Enum variants become labels.
+`Box`, `Option`, `Vec` are indirection. The type system has named every
+node and every reference long before any visualization tool sees it.
 
-```toml
-[dependencies]
-caraspace = "0.1"
-serde = { version = "1", features = ["derive"] }
-```
-
-## The swap
+Caraspace refines that structure into a faithful picture instead of nested
+text, and exposes it through the macro you already reach for:
 
 ```diff
 - std::dbg!(tree)
 + caraspace::dbg!(tree)
 ```
 
-Or shadow it for the whole module:
-
-```rust
-use caraspace::dbg;
-```
-
-The calling convention matches `std::dbg!` exactly:
-
-| Form         | Behavior                                                          |
-|--------------|-------------------------------------------------------------------|
-| `dbg!()`     | Prints location to stderr (same as `std::dbg!()`)                 |
-| `dbg!(x)`    | Prints `{:#?}` + opens diagram, returns `x` through               |
-| `dbg!(&x)`   | Same, borrows                                                     |
-| `dbg!(a, b)` | Returns `(a, b)`; one diagram tab per argument                    |
-
-Type requirements: `Debug` (already required by `std::dbg!`), plus `Serialize`
-and `SpytialDecorators`:
+stderr stays byte-identical. The browser opens an interactive diagram of
+the same value. `caraspace::dbg!` is a strict superset of `std::dbg!` —
+same calling convention, same return semantics, plus the picture.
 
 ```rust
 use caraspace::{dbg, SpytialDecorators};
@@ -72,54 +48,123 @@ struct Node {
     left: Option<Box<Node>>,
     right: Option<Box<Node>>,
 }
+
+let tree = build_tree();
+let tree = dbg!(tree);
 ```
 
-That's the whole setup. `SPYTIAL_NO_OPEN=1` suppresses browser launch (CI,
-tests, headless runs) — stderr is unaffected, so `cargo test` capture behaves
-exactly like it does for `std::dbg!`.
+The longer version of this argument — including the BDD example that
+motivates the design and the cross-language story — is on Brown PLT's
+blog: [Diagramming Program Values by Spatial Refinement](https://blog.brownplt.org/2026/05/22/spytial.html).
 
-## When you want more than the default layout
+## Decorators are specs, not draw calls
 
-Caraspace decorators (`#[attribute]`, `#[align]`, `#[orientation]`,
-`#[atom_color]`, …) tell the diagrammer what to emphasise — relative
-position, color, alignment, grouping. They're declarative constraints, not
-imperative rendering code:
+The default layout will get you most of the way for trees and lists, but
+real diagrams want a few hints. Caraspace decorators describe *what should
+hold* about the layout — not *how to render* it. They're declarative
+constraints, attached to the type once, applied everywhere a value of that
+type appears.
+
+Watch a red-black tree clarify as constraints accumulate.
+
+**Stage 1: bare derive.** Three derives, no decorators. The diagram is a
+graph — every node and edge is correct, but it's flat.
 
 ```rust
 #[derive(Debug, Serialize, SpytialDecorators)]
-#[attribute(field = "key")]
-#[attribute(field = "color")]
-#[orientation(selector = "{x, y : RBNode | x->y in left}",  directions = ["left",  "below"])]
-#[orientation(selector = "{x, y : RBNode | x->y in right}", directions = ["right", "below"])]
-#[atom_color(selector = "{x : RBNode | @:(x.color) = Red}",   value = "red")]
-#[atom_color(selector = "{x : RBNode | @:(x.color) = Black}", value = "black")]
-struct RBNode { /* ... */ }
+struct RBNode {
+    key: u32,
+    color: Color,
+    left: Option<Box<RBNode>>,
+    right: Option<Box<RBNode>>,
+}
 ```
 
-Decorators are collected from nested types automatically — decorating
-`Person` once is enough for those decorators to apply wherever `Person`
-appears inside another decorated type. `Vec<T>`, `Option<T>`, `Box<T>`, and
-their nested combinations all unwrap during the compile-time walk.
+**Stage 2: show the key.** Without this, nodes are just anonymous atoms.
 
-Full attribute reference: [USER_GUIDE.md](./USER_GUIDE.md).
+```rust
+#[attribute(field = "key")]
+```
 
-## Without `dbg!`
+**Stage 3: make it a tree.** Left children go down-and-left, right
+children go down-and-right. Now the layout encodes BST order visually.
 
-For library code, or anywhere you don't want stderr noise, call `diagram`
-directly:
+```rust
+#[orientation(selector = "{x, y : RBNode | x->y in left}",  directions = ["left",  "below"])]
+#[orientation(selector = "{x, y : RBNode | x->y in right}", directions = ["right", "below"])]
+```
+
+**Stage 4: make it a *red-black* tree.** Color the nodes by their `Color`
+field. The selector pattern matches *any* `RBNode` whose `color` is `Red`
+— rules are over structure, not specific instances.
+
+```rust
+#[atom_color(selector = "{x : RBNode | @:(x.color) = Red}",   value = "red")]
+#[atom_color(selector = "{x : RBNode | @:(x.color) = Black}", value = "black")]
+```
+
+**Stage 5: hide the scaffolding.** The `Color` enum atoms and the `None`
+sentinels aren't interesting — their effect is already visible in node
+color and absent edges. Drop them from the canvas.
+
+```rust
+#[hide_atom(selector = "Color + u32 + None")]
+```
+
+Each rule refines an existing structure rather than imposing an external
+aesthetic. None of them say where any specific node goes; they say which
+*relationships* should hold across every node of the matching shape. Add
+a sixth constraint and the diagram stays consistent. Remove one and the
+diagram still parses your value — it just looks less specific.
+
+Decorators are collected transitively. Decorating `Person` once is enough
+for those decorators to apply wherever `Person` appears inside another
+decorated type — `Vec<T>`, `Option<T>`, `Box<T>`, and their nested
+combinations all unwrap during the compile-time walk. No central registry,
+no runtime registration.
+
+The full progressive demo lives in [`examples/rbt.rs`](./examples/rbt.rs).
+
+## Install
+
+```toml
+[dependencies]
+caraspace = "0.1"
+serde = { version = "1", features = ["derive"] }
+```
+
+## Reference
+
+`dbg!` matches the `std::dbg!` calling convention:
+
+| Form         | Behavior                                                          |
+|--------------|-------------------------------------------------------------------|
+| `dbg!()`     | Prints location to stderr (same as `std::dbg!()`)                 |
+| `dbg!(x)`    | Prints `{:#?}` + opens diagram, returns `x` through               |
+| `dbg!(&x)`   | Same, borrows                                                     |
+| `dbg!(a, b)` | Returns `(a, b)`; one diagram tab per argument                    |
+
+Type requirements: `Debug` (already required by `std::dbg!`), plus
+`Serialize` and `SpytialDecorators`. `SPYTIAL_NO_OPEN=1` suppresses browser
+launch — stderr is unaffected, so `cargo test` capture behaves exactly
+like it does for `std::dbg!`.
+
+For library code, or anywhere you don't want stderr noise:
 
 ```rust
 use caraspace::diagram;
-diagram(&tree); // no stderr line, no source location, doesn't move
+diagram(&tree); // no stderr, no source location, doesn't move
 ```
+
+Full decorator attribute reference: [USER_GUIDE.md](./USER_GUIDE.md).
 
 ## Examples
 
-| Example       | What it shows                                          |
-|---------------|--------------------------------------------------------|
-| `dbg_basic`   | The smallest `dbg!` swap                               |
-| `demo`        | Decorator collection across nested structs             |
-| `rbt`         | Insertion-balanced red-black tree with layout + colors |
+| Example       | What it shows                                              |
+|---------------|------------------------------------------------------------|
+| `dbg_basic`   | The smallest `dbg!` swap                                   |
+| `demo`        | Decorator collection across nested structs                 |
+| `rbt`         | Red-black tree progressive refinement (Stages 1–5 above)   |
 
 ```bash
 cargo run --example dbg_basic
@@ -134,14 +179,14 @@ docker run --rm -p 8080:8080 caraspace          # default: rbt
 docker run --rm -p 8080:8080 caraspace demo
 ```
 
-Open `http://localhost:8080/rust_viz_data.html`. Browser launch is disabled
-inside the container (`SPYTIAL_NO_OPEN=1`).
+Open `http://localhost:8080/rust_viz_data.html`. Browser launch is
+disabled inside the container (`SPYTIAL_NO_OPEN=1`).
 
 ## Docs
 
 - [USER_GUIDE.md](./USER_GUIDE.md) — full decorator reference, common workflows
 - [doc.md](./doc.md) — compile-time analysis internals
-- [Spytial blog post](https://blog.brownplt.org/2026/05/22/spytial.html) — design philosophy
+- [Spytial blog post](https://blog.brownplt.org/2026/05/22/spytial.html) — design philosophy and motivating examples
 
 ## Development
 

--- a/examples/dbg_basic.rs
+++ b/examples/dbg_basic.rs
@@ -1,0 +1,44 @@
+//! Minimal end-to-end example of `caraspace::dbg!`.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --example dbg_basic
+//! ```
+//!
+//! Or headless (no browser):
+//!
+//! ```sh
+//! SPYTIAL_NO_OPEN=1 cargo run --example dbg_basic
+//! ```
+
+use caraspace::{dbg, SpytialDecorators};
+use serde::Serialize;
+
+#[derive(Debug, Serialize, SpytialDecorators)]
+#[attribute(field = "key")]
+struct Node {
+    key: u32,
+    left: Option<Box<Node>>,
+    right: Option<Box<Node>>,
+}
+
+fn main() {
+    let tree = Node {
+        key: 5,
+        left: Some(Box::new(Node {
+            key: 3,
+            left: None,
+            right: None,
+        })),
+        right: Some(Box::new(Node {
+            key: 7,
+            left: None,
+            right: None,
+        })),
+    };
+
+    // Drop in for `std::dbg!`: opens a browser tab with the diagram,
+    // returns the value through for further use.
+    let _tree = dbg!(tree);
+}

--- a/examples/rbt.rs
+++ b/examples/rbt.rs
@@ -1,14 +1,14 @@
-use caraspace::{diagram, SpytialDecorators};
+use caraspace::{dbg, SpytialDecorators};
 use serde::Serialize;
 
-#[derive(Serialize, SpytialDecorators)]
+#[derive(Debug, Serialize, SpytialDecorators)]
 struct RBTree {
     root: Option<Box<RBNode>>,
 }
 
 /// RBNode in the red-black tree with decorators that will be automatically
 /// included when processing any type that contains RBNode fields.
-#[derive(Serialize, SpytialDecorators)]
+#[derive(Debug, Serialize, SpytialDecorators)]
 #[attribute(field = "key")]
 #[attribute(field = "color")]
 #[orientation(selector="{x, y : RBNode | x->y in left}", directions=["left", "below"])]
@@ -203,5 +203,5 @@ fn main() {
 
     assert!(tree.is_valid(), "red-black invariants should hold");
 
-    diagram(&tree);
+    dbg!(tree);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,84 @@ pub fn diagram_with_spec<T: Serialize>(value: &T, spec: &str) {
     diagram_impl(value, spec);
 }
 
+/// Strict superset of [`std::dbg!`]: prints the `Debug` representation to
+/// stderr *and* opens an interactive diagram of the value in your browser.
+///
+/// The calling convention matches `std::dbg!` exactly, so swapping
+/// `std::dbg!` for `caraspace::dbg!` (or `use caraspace::dbg;`) is purely
+/// additive — you keep the stderr trail you already rely on and get the
+/// diagram on top.
+///
+/// - `dbg!()` — prints the source location, opens nothing.
+/// - `dbg!(expr)` — evaluates `expr`, prints `[file:line:col] expr = …` to
+///   stderr (using `{:#?}`), opens a diagram in the browser, and returns
+///   the value through.
+/// - `dbg!(a, b, …)` — returns a tuple `(a, b, …)`. Each argument is
+///   diagrammed (opens one tab per argument).
+///
+/// The expression's type must derive [`std::fmt::Debug`],
+/// [`serde::Serialize`], and [`SpytialDecorators`]. Both owned
+/// (`dbg!(x)`) and borrowed (`dbg!(&x)`) forms work.
+///
+/// # Examples
+///
+/// ```no_run
+/// use caraspace::{dbg, SpytialDecorators};
+/// use serde::Serialize;
+///
+/// #[derive(Debug, Serialize, SpytialDecorators)]
+/// #[attribute(field = "key")]
+/// struct Node {
+///     key: u32,
+///     left: Option<Box<Node>>,
+///     right: Option<Box<Node>>,
+/// }
+///
+/// let tree = Node {
+///     key: 5,
+///     left: Some(Box::new(Node { key: 3, left: None, right: None })),
+///     right: Some(Box::new(Node { key: 7, left: None, right: None })),
+/// };
+///
+/// // Drop in for `std::dbg!`: prints Debug + opens a diagram,
+/// // returns `tree` through for further use.
+/// let tree = dbg!(tree);
+/// ```
+///
+/// To suppress browser launch (CI, tests, headless runs), set
+/// `SPYTIAL_NO_OPEN=1`. Stderr output is unaffected, so `cargo test`
+/// captures still behave exactly like they would for `std::dbg!`.
+#[macro_export]
+macro_rules! dbg {
+    () => {
+        ::std::eprintln!(
+            "[{}:{}:{}]",
+            ::std::file!(),
+            ::std::line!(),
+            ::std::column!(),
+        )
+    };
+    ($val:expr $(,)?) => {
+        match $val {
+            tmp => {
+                ::std::eprintln!(
+                    "[{}:{}:{}] {} = {:#?}",
+                    ::std::file!(),
+                    ::std::line!(),
+                    ::std::column!(),
+                    ::std::stringify!($val),
+                    &tmp,
+                );
+                $crate::diagram(&tmp);
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($($crate::dbg!($val)),+,)
+    };
+}
+
 /// Internal implementation shared by diagram functions.
 fn diagram_impl<T: Serialize>(value: &T, spec: &str) {
     // Export the struct to our custom JSON format with type information

--- a/src/spytial_annotations/runtime.rs
+++ b/src/spytial_annotations/runtime.rs
@@ -336,6 +336,12 @@ pub trait HasSpytialDecorators {
     fn decorators() -> SpytialDecorators;
 }
 
+impl<T: HasSpytialDecorators + ?Sized> HasSpytialDecorators for &T {
+    fn decorators() -> SpytialDecorators {
+        T::decorators()
+    }
+}
+
 // ── Probe mechanism for safe compile-time decorator collection ──────────
 //
 // Problem: the derive macro needs to collect decorators from field types,


### PR DESCRIPTION
## Summary

- `caraspace::dbg!` is now a strict superset of `std::dbg!`: prints the same `[file:line:col] expr = {:#?}` stderr trail **and** opens an interactive diagram in the browser. Swap is one line: `s/std::dbg!/caraspace::dbg!/` or `use caraspace::dbg;` to shadow.
- Supports the full `std::dbg!` calling convention: `dbg!()`, `dbg!(x)`, `dbg!(&x)`, `dbg!(a, b, …)` returns `(a, b, …)`.
- Hero of the README rewritten around the swap, framed against the [Spytial post on Brown PLT's blog](https://blog.brownplt.org/2026/05/22/spytial.html). The pitch is the printf-debugging-but-for-shapes story, made literal.
- Flagship `rbt` example now uses `dbg!(tree)` so the canonical demo runs the new idiom. New minimal `dbg_basic` example matches the README copy.

## Details

- Blanket `impl<T: HasSpytialDecorators + ?Sized> HasSpytialDecorators for &T` in [src/spytial_annotations/runtime.rs](src/spytial_annotations/runtime.rs) so `dbg!(&x)` compiles without forcing users to choose between move and borrow.
- The macro lives in [src/lib.rs](src/lib.rs) as a `#[macro_export]`ed `macro_rules!`. No proc-macro, no runtime feature gate.
- `SPYTIAL_NO_OPEN=1` continues to suppress browser launch only — stderr output is preserved, so `cargo test` capture behaves identically to `std::dbg!` users would expect.

## Migration

```diff
- std::dbg!(tree)
+ caraspace::dbg!(tree)
```

Requirements on the value's type: `Debug` (same as `std::dbg!`) plus `Serialize` and `SpytialDecorators` for caraspace's existing relational export.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib --tests` — 21/21 pass
- [x] `cargo test --doc` — 2/2 pass (covers the new `dbg!` example)
- [x] `SPYTIAL_NO_OPEN=1 cargo run --example dbg_basic` — stderr output matches `std::dbg!` shape; diagram suppressed via env var
- [x] `SPYTIAL_NO_OPEN=1 cargo run --example rbt` — same; full RB tree Debug dump appears alongside what would be the diagram

## Try it

```bash
cargo run --example dbg_basic   # smallest swap
cargo run --example rbt         # realistic complex demo
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)