### PR TITLE
Prep crates.io release v0.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ test_output.html
 .DS_Store
 Thumbs.db
 
-macros/target/debug
+macros/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "caraspace"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 rust-version = "1.80"
-description = "Rust integration layer for Spytial diagram generation"
+description = "Drop-in replacement for std::dbg! that opens an interactive diagram of Rust values (Spytial for Rust)."
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/sidprasad/caraspace"
-keywords = ["rust", "spytial", "visualization", "graph"]
+keywords = ["spytial", "visualization", "diagram", "debugging", "graph"]
 categories = ["visualization", "development-tools"]
 
 [dependencies]
@@ -15,6 +15,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yml = "0.0"
 serde-value = "0.7"
-caraspace_export_macros = { path = "./macros" }
+caraspace_export_macros = { version = "0.0.1", path = "./macros" }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The full progressive demo lives in [`examples/rbt.rs`](./examples/rbt.rs).
 
 ```toml
 [dependencies]
-caraspace = "0.1"
+caraspace = "0.0"
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -17,7 +17,7 @@ Add the crate to your project:
 
 ```toml
 [dependencies]
-caraspace = { path = "/path/to/caraspace" }
+caraspace = "0.0"
 serde = { version = "1", features = ["derive"] }
 ```
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "caraspace_export_macros"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
+rust-version = "1.80"
+description = "Procedural macros for the caraspace crate (SpytialDecorators derive)."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/sidprasad/caraspace"
 
 [lib]
 proc-macro = true

--- a/src/export.rs
+++ b/src/export.rs
@@ -608,7 +608,7 @@ impl<'a> Serializer for &'a mut JsonDataSerializer {
 /// These implement the `idx(container, position, element)` relationalization pattern
 /// for collections where position has stable, meaningful semantics.
 
-/// ## Vec<T>, arrays, slices - O(1) indexable collections
+/// ## `Vec<T>`, arrays, slices - O(1) indexable collections
 ///
 /// **Serialization Pattern**: Each element creates an `idx` relation
 /// **Position Encoding**: String representation of 0-based index


### PR DESCRIPTION
## Summary

Sets both crates to v0.0.1, adds the publish metadata the macros sub-crate was missing, points the macros dependency at a real version, and clears the `cargo doc` warning so docs.rs renders cleanly.

## What changed

- **`caraspace` v0.0.1**: refined description to lead with the dbg!/debug framing, added `diagram` + `debugging` to keywords, pinned the macros dep to `version = "0.0.1"` alongside the path (without this, `cargo publish` rejects the upload).
- **`caraspace_export_macros` v0.0.1**: added `description`, `license`, `repository`, and `rust-version`. The sub-crate had none of these — crates.io requires `description` + `license` minimum.
- **README.md** / **USER_GUIDE.md**: install snippets now show `caraspace = "0.0"` instead of `0.1` and the local `path = ` form.
- **src/export.rs**: wrapped `Vec<T>` in a doc comment so rustdoc stops parsing it as HTML (was the only warning blocking a clean `cargo doc`).
- **.gitignore**: extended `macros/target/debug` to `macros/target/` so publish-artifact directories don't appear as untracked files.

## Dry-run results

- `cargo publish --dry-run --allow-dirty` (inside `./macros/`) — packages cleanly, 7 files, 32.7 KiB → 7.1 KiB compressed.
- `cargo publish --dry-run --allow-dirty` (root) — fails as expected with `no matching package named caraspace_export_macros found` because the sub-crate isn't on crates.io yet. This will pass once the sub-crate is actually published.
- `cargo doc --no-deps` — clean, no warnings.
- `cargo test --lib --tests` — 21/21 pass.

## Publish sequence (separate from this PR)

After merge:

```bash
cd macros && cargo publish
# wait ~30s for the crates.io index to update
cd .. && cargo publish
```

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib --tests` (21 pass)
- [x] `cargo test --doc` (2 pass)
- [x] `cargo doc --no-deps` (no warnings)
- [x] `cargo publish --dry-run --allow-dirty` on `caraspace_export_macros` succeeds
- [ ] `cargo publish --dry-run --allow-dirty` on `caraspace` succeeds (will succeed once macros sub-crate is published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)