### PR TITLE
Add tag-driven release workflow with crates.io trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Required for OIDC token exchange with crates.io trusted publishing.
+      id-token: write
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish caraspace_export_macros
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --manifest-path macros/Cargo.toml
+
+      - name: Wait for crates.io index to update
+        run: sleep 60
+
+      - name: Publish caraspace
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,105 @@
+# Releasing caraspace
+
+This repo publishes two crates to crates.io:
+
+- `caraspace_export_macros` — the proc-macro sub-crate (must publish first)
+- `caraspace` — the main crate (depends on the above)
+
+Releases run via OIDC-based [trusted publishing](https://crates.io/docs/trusted-publishing).
+After a one-time bootstrap, no long-lived crates.io tokens live anywhere —
+GitHub Actions exchanges a short-lived OIDC token for a 30-minute crates.io
+token on each release.
+
+## One-time bootstrap (token-based)
+
+Crates.io's trusted publishing requires each crate to have been published
+at least once via a regular API token before OIDC can be configured.
+Skip this section if both `caraspace` and `caraspace_export_macros` are
+already on crates.io.
+
+1. Get a token from https://crates.io/me with the `publish-new` scope.
+   Log in once:
+
+   ```bash
+   cargo login <token>
+   ```
+
+2. Publish the macros sub-crate first:
+
+   ```bash
+   cd macros
+   cargo publish
+   ```
+
+3. Wait ~60 seconds for the crates.io index to propagate.
+
+4. Publish the main crate:
+
+   ```bash
+   cd ..
+   cargo publish
+   ```
+
+5. Once both crates are live, configure trusted publishing (next section)
+   so future releases don't need a token.
+
+## Configure trusted publishing (one-time per crate)
+
+For each crate (`caraspace` and `caraspace_export_macros`):
+
+1. Sign in to https://crates.io with the GitHub account that owns the crate
+2. Navigate to the crate's settings → **Trusted Publishers**
+3. Add a new GitHub Actions publisher with:
+   - **Repository owner**: `sidprasad`
+   - **Repository name**: `caraspace`
+   - **Workflow filename**: `release.yml`
+   - **Environment**: (leave empty)
+
+Once both crates have trusted publishing configured, you can optionally
+disable token-based publishing in each crate's settings — that prevents
+any leaked token from being able to publish.
+
+## Releasing a new version
+
+1. On a branch, bump versions in `Cargo.toml` (both `version` and the
+   `caraspace_export_macros` dependency) and in `macros/Cargo.toml`. Keep
+   them in sync.
+2. Open and merge the version-bump PR.
+3. From `main`, tag and push:
+
+   ```bash
+   git checkout main
+   git pull
+   git tag v0.0.2
+   git push origin v0.0.2
+   ```
+
+4. The `Release` workflow at `.github/workflows/release.yml` runs
+   automatically and:
+   - Authenticates to crates.io via OIDC (no token used)
+   - Publishes `caraspace_export_macros`
+   - Waits 60 seconds for the index to update
+   - Publishes `caraspace`
+
+Watch progress at https://github.com/sidprasad/caraspace/actions.
+
+The workflow also supports manual triggering via `workflow_dispatch` if a
+release needs to be re-run (e.g. after a transient crates.io failure on
+the second publish — the macros crate is already up; trigger the workflow
+again and the macros publish will fail-fast on "already exists" while the
+main crate publish goes through).
+
+## Troubleshooting
+
+**`error: failed to verify package tarball` during the second publish.**
+The crates.io index is eventually consistent. The workflow sleeps 60s
+between publishes; if you're running manually, wait longer between the two
+`cargo publish` calls.
+
+**`error: api errors (status 403 Forbidden)`** during the OIDC step.
+The trusted publisher configuration on crates.io doesn't match the
+workflow run trying to publish. Verify that the repository owner,
+repository name, and workflow filename match exactly (case sensitive).
+
+**Workflow doesn't run on tag push.** Check that the tag name starts with
+`v` (e.g. `v0.0.2`, not `0.0.2`). The trigger is `tags: ['v*']`.


### PR DESCRIPTION
## Summary

Wire up [crates.io trusted publishing](https://crates.io/docs/trusted-publishing) so future releases of `caraspace` + `caraspace_export_macros` happen via GitHub Actions OIDC — no long-lived API tokens stored anywhere.

- **`.github/workflows/release.yml`** — triggered on tags matching `v*` (or `workflow_dispatch`). Uses [`rust-lang/crates-io-auth-action@v1`](https://github.com/rust-lang/crates-io-auth-action) to exchange the GitHub OIDC token for a 30-minute crates.io token, then publishes the macros sub-crate, waits 60s for the index, then publishes the main crate.
- **`RELEASING.md`** — full walkthrough: one-time bootstrap, per-crate trusted-publisher config on crates.io, and the tag-and-push flow for subsequent releases. Includes troubleshooting.

## Why a bootstrap step is needed

[RFC 3691](https://rust-lang.github.io/rfcs/3691-trusted-publishing-cratesio.html) explicitly says:

> A Trusted Publisher Configuration can only be created after an initial manual publishing of a crate.

"Pending publishers" (configuring TP for an unpublished crate name) is listed as future work but not yet implemented. So the path is: one token-based publish → configure TP → all future releases via tag push.

## What you (the maintainer) need to do after merging

1. **Bootstrap-publish v0.0.1 manually** (one time only):
   ```bash
   cargo login <token-from-https://crates.io/me>
   cd macros && cargo publish
   sleep 60
   cd .. && cargo publish
   ```
2. **Configure trusted publishing** on crates.io for each crate (settings → Trusted Publishers):
   - Repository owner: `sidprasad`
   - Repository name: `caraspace`
   - Workflow filename: `release.yml`
   - Environment: (empty)
3. **Future releases** are just:
   ```bash
   git tag v0.0.2
   git push origin v0.0.2
   ```
   The workflow runs and ships both crates.

Full walkthrough in [RELEASING.md](RELEASING.md).

## Test plan

The workflow can't be exercised end-to-end without actually publishing, but:

- [x] YAML syntax matches the conventions in `.github/workflows/pr.yml` and `main.yml`
- [x] Action versions match current upstream (`actions/checkout@v4`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`, `rust-lang/crates-io-auth-action@v1`)
- [x] `id-token: write` permission is set (required for OIDC)
- [x] `CARGO_REGISTRY_TOKEN` is wired from `steps.auth.outputs.token` per the action's docs
- [ ] First real tag-push test will be `v0.0.2` (after bootstrap + TP config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)