### PR TITLE
Add reify: reconstruct Rust values from a JsonDataInstance

### DIFF
--- a/src/jsondata.rs
+++ b/src/jsondata.rs
@@ -13,9 +13,29 @@ use serde::Serialize;
 ///
 /// Serialized as JSON in the HTML template and consumed by spytial-core's
 /// `JSONDataInstance` constructor in the browser.
+///
+/// # Root atom
+///
+/// Atoms are stored in serialization order, so **`atoms[0]` is the root** — the
+/// atom for the top-level value — because [`export_json_instance`] emits a
+/// container/struct atom before recursing into its children. Reconstruction
+/// relies on this: [`from_datum`] starts at `atoms[0]`, and [`from_datum_root`]
+/// takes an explicit id for callers that build or reorder an instance themselves.
+///
+/// There is intentionally **no `rootId` field**. For `export` output it would be
+/// redundant (the root is always `atoms[0]`, and the data is acyclic so the root
+/// is also recoverable as the atom that no relation targets), and it would not
+/// survive a spytial-core round-trip anyway, since unknown JSON keys are dropped.
+/// A future producer that needs an explicit root should pass it to
+/// [`from_datum_root`] rather than rely on a field that silently disappears.
+///
+/// [`export_json_instance`]: crate::export_json_instance
+/// [`from_datum`]: crate::from_datum
+/// [`from_datum_root`]: crate::from_datum_root
 #[derive(Serialize, Debug)]
 pub struct JsonDataInstance {
-    /// All atoms (graph nodes), in serialization order.
+    /// All atoms (graph nodes), in serialization order — `atoms[0]` is the root
+    /// (see the "Root atom" note on [`JsonDataInstance`]).
     pub atoms: Vec<IAtom>,
     /// All relations (edges), grouped by relation name.
     pub relations: Vec<IRelation>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,13 @@
 pub mod export;
 /// Serializable atom/relation data model consumed by spytial-core.
 pub mod jsondata;
+/// Reconstruct Rust values from the relational [`jsondata`] shape (inverse of [`export`]).
+pub mod reify;
 /// SpyTial decorator types, derive-macro runtime, and YAML serialization.
 pub mod spytial_annotations;
 
 pub use export::export_json_instance;
+pub use reify::{from_datum, from_datum_root, replit, replit_root, ReifyError};
 // Re-export the derive macro for spatial annotations
 pub use caraspace_export_macros::SpytialDecorators;
 use serde::Serialize;

--- a/src/reify.rs
+++ b/src/reify.rs
@@ -16,6 +16,14 @@
 //! index `Some(0)`, not a pointer). True `Rc<RefCell>` pointer cycles are not
 //! representable in the exported form and are out of scope; sharing/aliasing is
 //! not preserved (export duplicates it), which is invisible to `==`/`{:?}`.
+//!
+//! Known limitation — **nested `Option`**: `export` unwraps `Some` (it emits no
+//! wrapper atom) and shares a single `None` atom, so `Some(None)` and `None` are
+//! identical in the exported graph. `from_datum::<Option<Option<T>>>` therefore
+//! reconstructs `Some(None)` as `None`. Plain options and `Some(Some(x))` are
+//! unaffected. This is an export-side collapse — the `Some`-unwrapping is
+//! intentional (it keeps `Some(x)` rendering as `x` in the diagram) — not
+//! something `from_datum` can recover from the datum alone.
 
 use crate::jsondata::{IAtom, ITuple, JsonDataInstance};
 use serde::de::{

--- a/src/reify.rs
+++ b/src/reify.rs
@@ -1,7 +1,7 @@
 //! Reconstructing Rust values from the relational [`jsondata`](crate::jsondata)
 //! shape — the inverse of [`crate::export`].
 //!
-//! [`from_datum`] is a serde [`Deserializer`] over a
+//! [`from_datum`] is a serde `Deserializer` over a
 //! [`JsonDataInstance`](crate::jsondata::JsonDataInstance): it walks the flat
 //! atom/relation graph from a root atom and rebuilds a genuine `T`, so `{:?}`
 //! runs the real [`Debug`] impl. [`replit`] is
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::fmt::{self, Debug, Display};
 
 /// Error produced while reconstructing a value from a
-/// [`JsonDataInstance`](crate::jsondata::JsonDataInstance).
+/// [`JsonDataInstance`].
 #[derive(Debug, Clone)]
 pub struct ReifyError(String);
 

--- a/src/reify.rs
+++ b/src/reify.rs
@@ -1,0 +1,590 @@
+//! Reconstructing Rust values from the relational [`jsondata`](crate::jsondata)
+//! shape — the inverse of [`crate::export`].
+//!
+//! [`from_datum`] is a serde [`Deserializer`] over a
+//! [`JsonDataInstance`](crate::jsondata::JsonDataInstance): it walks the flat
+//! atom/relation graph from a root atom and rebuilds a genuine `T`, so `{:?}`
+//! runs the real [`Debug`] impl. [`replit`] is
+//! `format!("{:?}", from_datum::<T>(..)?)` — the REPL/`Debug`-equivalent string.
+//!
+//! # Scope
+//!
+//! Covers the full serde tree model: primitives, `Option`, sequences, tuples,
+//! tuple/newtype/unit structs, maps, structs, and all enum variant shapes. That
+//! is exactly what [`crate::export`] produces, which is acyclic by construction
+//! — arena/index "graphs" round-trip as plain data (a self-loop is the integer
+//! index `Some(0)`, not a pointer). True `Rc<RefCell>` pointer cycles are not
+//! representable in the exported form and are out of scope; sharing/aliasing is
+//! not preserved (export duplicates it), which is invisible to `==`/`{:?}`.
+
+use crate::jsondata::{IAtom, ITuple, JsonDataInstance};
+use serde::de::{
+    self, DeserializeOwned, DeserializeSeed, Deserializer, EnumAccess, MapAccess, SeqAccess,
+    VariantAccess, Visitor,
+};
+use std::collections::HashMap;
+use std::fmt::{self, Debug, Display};
+
+/// Error produced while reconstructing a value from a
+/// [`JsonDataInstance`](crate::jsondata::JsonDataInstance).
+#[derive(Debug, Clone)]
+pub struct ReifyError(String);
+
+impl ReifyError {
+    fn msg(s: impl Into<String>) -> Self {
+        ReifyError(s.into())
+    }
+
+    /// Borrow the underlying error message.
+    pub fn message(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for ReifyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "reify error: {}", self.0)
+    }
+}
+
+impl std::error::Error for ReifyError {}
+
+impl de::Error for ReifyError {
+    fn custom<T: Display>(msg: T) -> Self {
+        ReifyError(msg.to_string())
+    }
+}
+
+/// Reconstruct a `T` from a data instance, starting at the first atom.
+///
+/// [`crate::export`] emits the root value first, so `atoms[0]` is the root. Use
+/// [`from_datum_root`] to start from a specific atom id instead.
+pub fn from_datum<T: DeserializeOwned>(datum: &JsonDataInstance) -> Result<T, ReifyError> {
+    let root = datum
+        .atoms
+        .first()
+        .ok_or_else(|| ReifyError::msg("empty data instance: no atoms"))?;
+    from_datum_root(datum, &root.id)
+}
+
+/// Reconstruct a `T` starting from an explicit root atom id.
+pub fn from_datum_root<T: DeserializeOwned>(
+    datum: &JsonDataInstance,
+    root_id: &str,
+) -> Result<T, ReifyError> {
+    let index = Index::build(datum);
+    let root_key = *index
+        .atoms
+        .get_key_value(root_id)
+        .ok_or_else(|| ReifyError::msg(format!("root atom not found: {root_id}")))?
+        .0;
+    T::deserialize(NodeDeserializer {
+        index: &index,
+        atom_id: root_key,
+    })
+}
+
+/// Reconstruct a `T` and return its `Debug` string — the REPL-equivalent output.
+///
+/// Equivalent to `format!("{:?}", from_datum::<T>(datum)?)`. Because the value
+/// is parsed into a real `T` and Rust's own `Debug` re-renders it, this matches
+/// `format!("{:?}", original)` exactly (custom `Debug` impls included).
+pub fn replit<T: DeserializeOwned + Debug>(datum: &JsonDataInstance) -> Result<String, ReifyError> {
+    Ok(format!("{:?}", from_datum::<T>(datum)?))
+}
+
+/// [`replit`] starting from an explicit root atom id.
+pub fn replit_root<T: DeserializeOwned + Debug>(
+    datum: &JsonDataInstance,
+    root_id: &str,
+) -> Result<String, ReifyError> {
+    Ok(format!("{:?}", from_datum_root::<T>(datum, root_id)?))
+}
+
+// ---------------------------------------------------------------------------
+// Internal index over the flat atom/relation graph
+// ---------------------------------------------------------------------------
+
+struct Index<'a> {
+    atoms: HashMap<&'a str, &'a IAtom>,
+    /// source atom id -> relation name -> tuples whose first atom is that source
+    out: HashMap<&'a str, HashMap<&'a str, Vec<&'a ITuple>>>,
+}
+
+impl<'a> Index<'a> {
+    fn build(d: &'a JsonDataInstance) -> Self {
+        let atoms = d.atoms.iter().map(|a| (a.id.as_str(), a)).collect();
+        let mut out: HashMap<&str, HashMap<&str, Vec<&ITuple>>> = HashMap::new();
+        for rel in &d.relations {
+            for t in &rel.tuples {
+                if let Some(src) = t.atoms.first() {
+                    out.entry(src.as_str())
+                        .or_default()
+                        .entry(rel.name.as_str())
+                        .or_default()
+                        .push(t);
+                }
+            }
+        }
+        Index { atoms, out }
+    }
+
+    fn atom(&self, id: &str) -> Result<&'a IAtom, ReifyError> {
+        self.atoms
+            .get(id)
+            .copied()
+            .ok_or_else(|| ReifyError::msg(format!("atom not found: {id}")))
+    }
+
+    /// The single target of a binary relation `rel` from `src` (its second atom).
+    fn single_target(&self, src: &str, rel: &str) -> Result<&'a str, ReifyError> {
+        self.out
+            .get(src)
+            .and_then(|m| m.get(rel))
+            .and_then(|v| v.first())
+            .and_then(|t| t.atoms.get(1))
+            .map(|s| s.as_str())
+            .ok_or_else(|| ReifyError::msg(format!("missing relation '{rel}' from atom {src}")))
+    }
+
+    /// Element atom ids for a sequence/tuple, ordered by the `idx` position.
+    fn seq_elems(&self, src: &str) -> Vec<&'a str> {
+        let mut items: Vec<(usize, &'a str)> = Vec::new();
+        if let Some(tuples) = self.out.get(src).and_then(|m| m.get("idx")) {
+            for t in tuples {
+                if let (Some(pos), Some(elem)) = (t.atoms.get(1), t.atoms.get(2)) {
+                    if let Ok(p) = pos.parse::<usize>() {
+                        items.push((p, elem.as_str()));
+                    }
+                }
+            }
+        }
+        items.sort_by_key(|(p, _)| *p);
+        items.into_iter().map(|(_, e)| e).collect()
+    }
+
+    /// (key atom id, value atom id) pairs for a map's `map_entry` relation.
+    fn map_entries(&self, src: &str) -> Vec<(&'a str, &'a str)> {
+        let mut v = Vec::new();
+        if let Some(tuples) = self.out.get(src).and_then(|m| m.get("map_entry")) {
+            for t in tuples {
+                if let (Some(k), Some(val)) = (t.atoms.get(1), t.atoms.get(2)) {
+                    v.push((k.as_str(), val.as_str()));
+                }
+            }
+        }
+        v
+    }
+
+    /// (field name, value atom id) pairs for a struct's field relations.
+    fn struct_fields(&self, src: &str) -> Vec<(&'a str, &'a str)> {
+        let mut v = Vec::new();
+        if let Some(m) = self.out.get(src) {
+            for (name, tuples) in m {
+                if let Some(t) = tuples.first() {
+                    if let Some(target) = t.atoms.get(1) {
+                        v.push((*name, target.as_str()));
+                    }
+                }
+            }
+        }
+        v
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Node deserializer: drives serde from a single atom
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+struct NodeDeserializer<'i, 'a> {
+    index: &'i Index<'a>,
+    atom_id: &'a str,
+}
+
+impl<'i, 'a> NodeDeserializer<'i, 'a> {
+    fn atom(&self) -> Result<&'a IAtom, ReifyError> {
+        self.index.atom(self.atom_id)
+    }
+
+    fn child(&self, id: &'a str) -> Self {
+        NodeDeserializer {
+            index: self.index,
+            atom_id: id,
+        }
+    }
+
+    fn parse<T>(&self) -> Result<T, ReifyError>
+    where
+        T: std::str::FromStr,
+        T::Err: Display,
+    {
+        let a = self.atom()?;
+        a.label.parse::<T>().map_err(|e| {
+            ReifyError::msg(format!(
+                "could not parse {} label '{}': {e}",
+                a.r#type, a.label
+            ))
+        })
+    }
+}
+
+macro_rules! deserialize_parsed {
+    ($method:ident, $visit:ident, $t:ty) => {
+        fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+            visitor.$visit(self.parse::<$t>()?)
+        }
+    };
+}
+
+impl<'i, 'a, 'de> Deserializer<'de> for NodeDeserializer<'i, 'a> {
+    type Error = ReifyError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, ReifyError> {
+        Err(ReifyError::msg(
+            "deserialize_any is unsupported: caraspace reify is type-driven, pass a concrete T",
+        ))
+    }
+
+    deserialize_parsed!(deserialize_bool, visit_bool, bool);
+    deserialize_parsed!(deserialize_i8, visit_i8, i8);
+    deserialize_parsed!(deserialize_i16, visit_i16, i16);
+    deserialize_parsed!(deserialize_i32, visit_i32, i32);
+    deserialize_parsed!(deserialize_i64, visit_i64, i64);
+    deserialize_parsed!(deserialize_i128, visit_i128, i128);
+    deserialize_parsed!(deserialize_u8, visit_u8, u8);
+    deserialize_parsed!(deserialize_u16, visit_u16, u16);
+    deserialize_parsed!(deserialize_u32, visit_u32, u32);
+    deserialize_parsed!(deserialize_u64, visit_u64, u64);
+    deserialize_parsed!(deserialize_u128, visit_u128, u128);
+    deserialize_parsed!(deserialize_f32, visit_f32, f32);
+    deserialize_parsed!(deserialize_f64, visit_f64, f64);
+
+    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        let a = self.atom()?;
+        let c = a
+            .label
+            .chars()
+            .next()
+            .ok_or_else(|| ReifyError::msg("empty char label"))?;
+        visitor.visit_char(c)
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        let a = self.atom()?;
+        visitor.visit_str(a.label.as_str())
+    }
+
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        let a = self.atom()?;
+        visitor.visit_string(a.label.clone())
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, ReifyError> {
+        Err(ReifyError::msg(
+            "bytes are not supported by caraspace reify yet",
+        ))
+    }
+
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        let a = self.atom()?;
+        if a.r#type == "None" {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, ReifyError> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, ReifyError> {
+        let inner = self.index.single_target(self.atom_id, "value")?;
+        visitor.visit_newtype_struct(self.child(inner))
+    }
+
+    fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        let elems = self.index.seq_elems(self.atom_id);
+        visitor.visit_seq(SeqWalker {
+            index: self.index,
+            elems,
+            pos: 0,
+        })
+    }
+
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, ReifyError> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, ReifyError> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        let entries = self.index.map_entries(self.atom_id);
+        visitor.visit_map(MapWalker {
+            index: self.index,
+            entries,
+            pos: 0,
+        })
+    }
+
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, ReifyError> {
+        let fields = self.index.struct_fields(self.atom_id);
+        visitor.visit_map(StructWalker {
+            index: self.index,
+            fields,
+            pos: 0,
+        })
+    }
+
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, ReifyError> {
+        let a = self.atom()?;
+        visitor.visit_enum(EnumWalker {
+            index: self.index,
+            atom_id: self.atom_id,
+            variant: a.label.as_str(),
+        })
+    }
+
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        visitor.visit_unit()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Access helpers for compound shapes
+// ---------------------------------------------------------------------------
+
+struct SeqWalker<'i, 'a> {
+    index: &'i Index<'a>,
+    elems: Vec<&'a str>,
+    pos: usize,
+}
+
+impl<'i, 'a, 'de> SeqAccess<'de> for SeqWalker<'i, 'a> {
+    type Error = ReifyError;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, ReifyError> {
+        if self.pos >= self.elems.len() {
+            return Ok(None);
+        }
+        let id = self.elems[self.pos];
+        self.pos += 1;
+        seed.deserialize(NodeDeserializer {
+            index: self.index,
+            atom_id: id,
+        })
+        .map(Some)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.elems.len() - self.pos)
+    }
+}
+
+struct MapWalker<'i, 'a> {
+    index: &'i Index<'a>,
+    entries: Vec<(&'a str, &'a str)>,
+    pos: usize,
+}
+
+impl<'i, 'a, 'de> MapAccess<'de> for MapWalker<'i, 'a> {
+    type Error = ReifyError;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, ReifyError> {
+        if self.pos >= self.entries.len() {
+            return Ok(None);
+        }
+        let (k, _) = self.entries[self.pos];
+        seed.deserialize(NodeDeserializer {
+            index: self.index,
+            atom_id: k,
+        })
+        .map(Some)
+    }
+
+    fn next_value_seed<Vv: DeserializeSeed<'de>>(
+        &mut self,
+        seed: Vv,
+    ) -> Result<Vv::Value, ReifyError> {
+        let (_, v) = self.entries[self.pos];
+        self.pos += 1;
+        seed.deserialize(NodeDeserializer {
+            index: self.index,
+            atom_id: v,
+        })
+    }
+}
+
+struct StructWalker<'i, 'a> {
+    index: &'i Index<'a>,
+    fields: Vec<(&'a str, &'a str)>,
+    pos: usize,
+}
+
+impl<'i, 'a, 'de> MapAccess<'de> for StructWalker<'i, 'a> {
+    type Error = ReifyError;
+
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, ReifyError> {
+        if self.pos >= self.fields.len() {
+            return Ok(None);
+        }
+        let (name, _) = self.fields[self.pos];
+        seed.deserialize(IdentDeserializer(name)).map(Some)
+    }
+
+    fn next_value_seed<Vv: DeserializeSeed<'de>>(
+        &mut self,
+        seed: Vv,
+    ) -> Result<Vv::Value, ReifyError> {
+        let (_, target) = self.fields[self.pos];
+        self.pos += 1;
+        seed.deserialize(NodeDeserializer {
+            index: self.index,
+            atom_id: target,
+        })
+    }
+}
+
+struct EnumWalker<'i, 'a> {
+    index: &'i Index<'a>,
+    atom_id: &'a str,
+    variant: &'a str,
+}
+
+impl<'i, 'a, 'de> EnumAccess<'de> for EnumWalker<'i, 'a> {
+    type Error = ReifyError;
+    type Variant = VariantWalker<'i, 'a>;
+
+    fn variant_seed<V: DeserializeSeed<'de>>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant), ReifyError> {
+        let value = seed.deserialize(IdentDeserializer(self.variant))?;
+        Ok((
+            value,
+            VariantWalker {
+                index: self.index,
+                atom_id: self.atom_id,
+            },
+        ))
+    }
+}
+
+struct VariantWalker<'i, 'a> {
+    index: &'i Index<'a>,
+    atom_id: &'a str,
+}
+
+impl<'i, 'a, 'de> VariantAccess<'de> for VariantWalker<'i, 'a> {
+    type Error = ReifyError;
+
+    fn unit_variant(self) -> Result<(), ReifyError> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(
+        self,
+        seed: T,
+    ) -> Result<T::Value, ReifyError> {
+        let inner = self.index.single_target(self.atom_id, "variant_value")?;
+        seed.deserialize(NodeDeserializer {
+            index: self.index,
+            atom_id: inner,
+        })
+    }
+
+    fn tuple_variant<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, ReifyError> {
+        let elems = self.index.seq_elems(self.atom_id);
+        visitor.visit_seq(SeqWalker {
+            index: self.index,
+            elems,
+            pos: 0,
+        })
+    }
+
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, ReifyError> {
+        let fields = self.index.struct_fields(self.atom_id);
+        visitor.visit_map(StructWalker {
+            index: self.index,
+            fields,
+            pos: 0,
+        })
+    }
+}
+
+/// Deserializer that yields a fixed string — used for struct field names and
+/// enum variant names, which are relation names / atom labels, not atoms.
+struct IdentDeserializer<'a>(&'a str);
+
+impl<'a, 'de> Deserializer<'de> for IdentDeserializer<'a> {
+    type Error = ReifyError;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        visitor.visit_str(self.0)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}

--- a/tests/reify.rs
+++ b/tests/reify.rs
@@ -1,0 +1,197 @@
+//! Round-trip tests for `caraspace::reify` — the inverse of `export`.
+//!
+//! Two oracles per case:
+//!   * **R-eq**       `v == from_datum(export(v))`               (exact value)
+//!   * **R-inspect**  `format!("{:?}", v) == replit(export(v))`  (Debug parity)
+//!
+//! Scope is everything-but-pointer-cycles: primitives, Option, sequences,
+//! tuples, structs (named/tuple/newtype/unit), enums (all variant shapes),
+//! maps, and arena/index "graphs" (cycles encoded as `usize` indices).
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use caraspace::{export_json_instance, from_datum, replit};
+use serde::{Deserialize, Serialize};
+
+/// R-eq only (use for types whose `{:?}` is order-sensitive, e.g. HashMap).
+fn eq_roundtrip<T>(v: T)
+where
+    T: Serialize + serde::de::DeserializeOwned + Debug + PartialEq,
+{
+    let di = export_json_instance(&v);
+    let back: T = from_datum(&di).unwrap_or_else(|e| panic!("from_datum failed: {e}"));
+    assert_eq!(v, back, "R-eq round-trip mismatch");
+}
+
+/// R-eq + R-inspect.
+fn full_roundtrip<T>(v: T)
+where
+    T: Serialize + serde::de::DeserializeOwned + Debug + PartialEq,
+{
+    let di = export_json_instance(&v);
+    let back: T = from_datum(&di).unwrap_or_else(|e| panic!("from_datum failed: {e}"));
+    assert_eq!(v, back, "R-eq round-trip mismatch");
+    let printed = replit::<T>(&di).unwrap_or_else(|e| panic!("replit failed: {e}"));
+    assert_eq!(
+        format!("{:?}", v),
+        printed,
+        "R-inspect ({{:?}}) parity mismatch"
+    );
+}
+
+#[test]
+fn primitives() {
+    full_roundtrip(42_i32);
+    full_roundtrip(-7_i64);
+    full_roundtrip(255_u8);
+    full_roundtrip(true);
+    full_roundtrip(false);
+    full_roundtrip('z');
+    full_roundtrip("hello".to_string());
+    full_roundtrip(String::new());
+}
+
+#[test]
+fn floats_canonicalize() {
+    // Even whole-number floats: label is "3", parse -> 3.0_f64, Debug -> "3.0",
+    // which matches the original's Debug.
+    full_roundtrip(3.0_f64);
+    full_roundtrip(3.5_f64);
+    full_roundtrip(-0.25_f32);
+    full_roundtrip(f64::INFINITY);
+}
+
+#[test]
+fn options() {
+    full_roundtrip(Some(5_i32));
+    full_roundtrip(Option::<i32>::None);
+    full_roundtrip(Some("x".to_string()));
+}
+
+#[test]
+fn sequences_and_tuples() {
+    full_roundtrip(vec![1_i32, 2, 3]);
+    full_roundtrip(Vec::<i32>::new());
+    full_roundtrip((1_i32, "x".to_string(), true));
+    full_roundtrip(vec![vec![1_i32], vec![], vec![2, 3]]);
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Line {
+    start: Point,
+    end: Point,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Pair(i32, i32);
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Meters(f64);
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Unit;
+
+#[test]
+fn structs() {
+    full_roundtrip(Point { x: 1, y: 2 });
+    full_roundtrip(Line {
+        start: Point { x: 1, y: 2 },
+        end: Point { x: 3, y: 4 },
+    });
+    full_roundtrip(Pair(3, 4));
+    full_roundtrip(Meters(2.5));
+    full_roundtrip(Unit);
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum Shape {
+    Empty,
+    Radius(f64),
+    Offset(i32, i32),
+    Rect { w: i32, h: i32 },
+}
+
+#[test]
+fn enums_all_variant_shapes() {
+    full_roundtrip(Shape::Empty);
+    full_roundtrip(Shape::Radius(1.5));
+    full_roundtrip(Shape::Offset(2, 3));
+    full_roundtrip(Shape::Rect { w: 10, h: 5 });
+    full_roundtrip(vec![
+        Shape::Empty,
+        Shape::Radius(2.0),
+        Shape::Rect { w: 1, h: 1 },
+    ]);
+}
+
+#[test]
+fn maps_eq_only() {
+    // {:?} for HashMap is iteration-order-dependent, so only R-eq applies.
+    let mut m = HashMap::new();
+    m.insert("a".to_string(), 1_i32);
+    m.insert("b".to_string(), 2);
+    m.insert("c".to_string(), 3);
+    eq_roundtrip(m);
+}
+
+// --- The headline: cyclic *graphs* via arena/index encoding ---
+//
+// A graph cycle is expressed as a `usize` index, so the *data* is acyclic and
+// round-trips through plain serde with full {:?} parity. No pointer cycles.
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct GraphNode {
+    val: i32,
+    next: Option<usize>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Graph {
+    nodes: Vec<GraphNode>,
+    root: usize,
+}
+
+#[test]
+fn arena_graph_with_index_cycles() {
+    // node 0 -> node 1 -> node 0  (a 2-cycle, encoded as indices)
+    let g = Graph {
+        nodes: vec![
+            GraphNode {
+                val: 1,
+                next: Some(1),
+            },
+            GraphNode {
+                val: 2,
+                next: Some(0),
+            },
+        ],
+        root: 0,
+    };
+    full_roundtrip(g);
+
+    // a self-loop: node 0 -> node 0
+    let g2 = Graph {
+        nodes: vec![GraphNode {
+            val: 42,
+            next: Some(0),
+        }],
+        root: 0,
+    };
+    full_roundtrip(g2);
+}
+
+#[test]
+fn explicit_root() {
+    // from_datum_root lets callers start from a chosen atom id; atom0 is the root.
+    let v = Point { x: 7, y: 8 };
+    let di = export_json_instance(&v);
+    let back: Point = caraspace::from_datum_root(&di, "atom0").unwrap();
+    assert_eq!(v, back);
+}

--- a/tests/reify.rs
+++ b/tests/reify.rs
@@ -195,3 +195,18 @@ fn explicit_root() {
     let back: Point = caraspace::from_datum_root(&di, "atom0").unwrap();
     assert_eq!(v, back);
 }
+
+#[test]
+fn nested_option_some_none_is_a_documented_collapse() {
+    // `export` unwraps `Some` and shares one `None` atom, so `Some(None)` and
+    // `None` are identical in the exported graph. Documented limitation (Codex
+    // review on #67): `Some(None)` reconstructs as `None`. The unwrapping is
+    // intentional — it keeps `Some(x)` rendering as `x` in the diagram.
+    let di = export_json_instance(&Some(Option::<i32>::None));
+    let back: Option<Option<i32>> = from_datum(&di).unwrap();
+    assert_eq!(back, None, "Some(None) collapses to None (export-side)");
+
+    // The nested-option cases that DO round-trip cleanly:
+    full_roundtrip(Some(Some(5_i32)));
+    full_roundtrip(Some(Some("x".to_string())));
+}


### PR DESCRIPTION
## What

Adds the inverse of `export`: a serde `Deserializer` over the flat `JsonDataInstance` graph.

- `from_datum::<T>(&JsonDataInstance) -> Result<T, ReifyError>` — walks the atom/relation graph from the root atom and rebuilds a **genuine `T`**. Because it produces a real value, `{:?}` runs the type's actual `Debug` impl.
- `from_datum_root::<T>(.., root_id)` — start from an explicit atom id.
- `replit::<T>(..) -> Result<String, ReifyError>` = `format!("{:?}", from_datum::<T>(..)?)` — the REPL/`Debug`-equivalent string. (Rust analogue of sPyTial's `replit` / `repr(reify(..))`; sibling to sidprasad/spytial#101.)

It's the dual of `JsonDataSerializer` in `export.rs`: one `deserialize_*` mirroring each `serialize_*`, navigating relations (`idx`, `map_entry`, struct field names, `value`/`variant_value`) outward from each atom.

## Scope

The full serde tree model — primitives, `Option`, sequences, tuples, tuple/newtype/unit structs, structs, maps, and all enum variant shapes. That's exactly what `export` produces, which is **acyclic by construction**:

- **Arena/index "graphs" round-trip fully**, with `{:?}` parity — a graph cycle is encoded as a `usize` index (e.g. `next: Some(0)`), so the data itself is acyclic.
- **Out of scope:** true `Rc<RefCell>` pointer cycles (not representable in the exported form — `export` is a pure serde tree-walk with no identity tracking, so it can't emit one) and sharing-preservation (export duplicates aliased subvalues; invisible to `==`/`{:?}` anyway).

Type-driven, so `deserialize_any` is unsupported (pass a concrete `T`). `bytes` isn't handled yet (`Vec<u8>` goes through `seq` and works).

A nice property falls out: **floats round-trip exactly.** `export` emits `f64::to_string()` (shortest round-trip form), so `parse` recovers the exact bits and `Debug` re-canonicalizes — `3.0` prints `3.0` on both ends.

## Tests

`tests/reify.rs` — per shape, both oracles: `v == from_datum(export(v))` (R-eq) and `format!("{:?}", v) == replit(export(v))` (Debug parity), including an arena graph with index-encoded cycles. Full suite green (9 new + existing); `cargo fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
