### PR TITLE
Faithful nested Option (Some/None) + topology root-finding

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -350,7 +350,29 @@ impl<'a> Serializer for &'a mut JsonDataSerializer {
     }
 
     fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok, Self::Error> {
-        value.serialize(self)
+        // Unwrap `Some` by default: `Some(x)` shares `x`'s atom, keeping the
+        // diagram clean (`Option<T>` points straight at the `T`). But when the
+        // inner is itself absent/optional — a `None` singleton or another `Some`
+        // wrapper — insert a `Some` wrapper atom so `Some(None)` stays distinct
+        // from `None` and arbitrarily nested options remain recoverable.
+        let inner_id = value.serialize(&mut *self)?;
+        let inner_is_optionish = self
+            .atoms
+            .iter()
+            .find(|a| a.id == inner_id)
+            .map(|a| a.r#type == "None" || a.r#type == "Some")
+            .unwrap_or(false);
+        if inner_is_optionish {
+            let some_id = self.emit_atom("Some", "Some");
+            self.push_relation(
+                "value",
+                vec![some_id.clone(), inner_id],
+                vec!["Some", "atom"],
+            );
+            Ok(some_id)
+        } else {
+            Ok(inner_id)
+        }
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {

--- a/src/reify.rs
+++ b/src/reify.rs
@@ -17,13 +17,10 @@
 //! representable in the exported form and are out of scope; sharing/aliasing is
 //! not preserved (export duplicates it), which is invisible to `==`/`{:?}`.
 //!
-//! Known limitation — **nested `Option`**: `export` unwraps `Some` (it emits no
-//! wrapper atom) and shares a single `None` atom, so `Some(None)` and `None` are
-//! identical in the exported graph. `from_datum::<Option<Option<T>>>` therefore
-//! reconstructs `Some(None)` as `None`. Plain options and `Some(Some(x))` are
-//! unaffected. This is an export-side collapse — the `Some`-unwrapping is
-//! intentional (it keeps `Some(x)` rendering as `x` in the diagram) — not
-//! something `from_datum` can recover from the datum alone.
+//! Nested `Option` round-trips faithfully: `export` unwraps `Some(x)` (so the
+//! common case stays a single clean atom) but inserts a `Some` wrapper atom when
+//! the inner is a `None`/`Some`, so `Some(None)` is distinct from `None` and any
+//! nesting depth is recoverable.
 
 use crate::jsondata::{IAtom, ITuple, JsonDataInstance};
 use serde::de::{
@@ -63,16 +60,42 @@ impl de::Error for ReifyError {
     }
 }
 
-/// Reconstruct a `T` from a data instance, starting at the first atom.
+/// Reconstruct a `T` from a data instance, starting at its root atom.
 ///
-/// [`crate::export`] emits the root value first, so `atoms[0]` is the root. Use
-/// [`from_datum_root`] to start from a specific atom id instead.
+/// The root is the atom that no relation targets (for `export` output, the
+/// top-level value). Use [`from_datum_root`] to start from a specific atom id.
 pub fn from_datum<T: DeserializeOwned>(datum: &JsonDataInstance) -> Result<T, ReifyError> {
-    let root = datum
+    from_datum_root(datum, find_root(datum)?)
+}
+
+/// The root atom: the first atom (in serialization order) that no relation
+/// targets. Robust to the `Some`-wrapper case, where `export` emits the wrapper
+/// *after* its inner — so `atoms[0]` is not always the root.
+fn find_root(datum: &JsonDataInstance) -> Result<&str, ReifyError> {
+    if datum.atoms.is_empty() {
+        return Err(ReifyError::msg("empty data instance: no atoms"));
+    }
+    let ids: std::collections::HashSet<&str> = datum.atoms.iter().map(|a| a.id.as_str()).collect();
+    let mut targeted: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for rel in &datum.relations {
+        for t in &rel.tuples {
+            // position 0 is the source; 1.. are targets (skip non-atom literals
+            // like the `idx` position string, which aren't real atom ids).
+            for tgt in t.atoms.iter().skip(1) {
+                if ids.contains(tgt.as_str()) {
+                    targeted.insert(tgt.as_str());
+                }
+            }
+        }
+    }
+    datum
         .atoms
-        .first()
-        .ok_or_else(|| ReifyError::msg("empty data instance: no atoms"))?;
-    from_datum_root(datum, &root.id)
+        .iter()
+        .map(|a| a.id.as_str())
+        .find(|id| !targeted.contains(id))
+        .ok_or_else(|| {
+            ReifyError::msg("no root atom: every atom is referenced (unexpected for export output)")
+        })
 }
 
 /// Reconstruct a `T` starting from an explicit root atom id.
@@ -300,10 +323,17 @@ impl<'i, 'a, 'de> Deserializer<'de> for NodeDeserializer<'i, 'a> {
 
     fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
         let a = self.atom()?;
-        if a.r#type == "None" {
-            visitor.visit_none()
-        } else {
-            visitor.visit_some(self)
+        match a.r#type.as_str() {
+            // `None` singleton.
+            "None" => visitor.visit_none(),
+            // `Some` wrapper — export inserts it only to keep an inner
+            // `None`/`Some` distinct; descend through its `value` relation.
+            "Some" => {
+                let inner = self.index.single_target(self.atom_id, "value")?;
+                visitor.visit_some(self.child(inner))
+            }
+            // Unwrapped `Some(x)`: the atom *is* `x`.
+            _ => visitor.visit_some(self),
         }
     }
 

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -184,6 +184,28 @@ fn option_none_produces_none_atom() {
     assert_eq!(target.r#type, "None");
 }
 
+#[derive(Serialize)]
+struct NestedOption {
+    v: Option<Option<u32>>,
+}
+
+#[test]
+fn some_wraps_only_around_inner_none() {
+    // Some(None) gets a `Some` wrapper atom pointing at the `None`, so it is
+    // distinguishable from a plain `None`. (Some of a non-option still unwraps,
+    // covered by option_some_unwraps_to_inner_value.)
+    let inst = export_json_instance(&NestedOption { v: Some(None) });
+    let target = atom_by_id(&inst, &relation(&inst, "v").tuples[0].atoms[1]);
+    assert_eq!(target.r#type, "Some");
+    let inner = atom_by_id(&inst, &relation(&inst, "value").tuples[0].atoms[1]);
+    assert_eq!(inner.r#type, "None");
+
+    // Plain None stays a bare None atom (no wrapper).
+    let inst_none = export_json_instance(&NestedOption { v: None });
+    let ntarget = atom_by_id(&inst_none, &relation(&inst_none, "v").tuples[0].atoms[1]);
+    assert_eq!(ntarget.r#type, "None");
+}
+
 // ──────────────────────────────────────────────
 // 5. Enum variants
 // ──────────────────────────────────────────────

--- a/tests/reify.rs
+++ b/tests/reify.rs
@@ -197,16 +197,14 @@ fn explicit_root() {
 }
 
 #[test]
-fn nested_option_some_none_is_a_documented_collapse() {
-    // `export` unwraps `Some` and shares one `None` atom, so `Some(None)` and
-    // `None` are identical in the exported graph. Documented limitation (Codex
-    // review on #67): `Some(None)` reconstructs as `None`. The unwrapping is
-    // intentional — it keeps `Some(x)` rendering as `x` in the diagram.
-    let di = export_json_instance(&Some(Option::<i32>::None));
-    let back: Option<Option<i32>> = from_datum(&di).unwrap();
-    assert_eq!(back, None, "Some(None) collapses to None (export-side)");
-
-    // The nested-option cases that DO round-trip cleanly:
-    full_roundtrip(Some(Some(5_i32)));
-    full_roundtrip(Some(Some("x".to_string())));
+fn nested_options_round_trip() {
+    // `export` inserts a `Some` wrapper only around an inner `None`/`Some`, so
+    // `Some(None)` is distinct from `None` and arbitrary nesting is recoverable,
+    // while `Some(non-option)` stays unwrapped. (Was the Codex #67 collapse;
+    // fixed for #68.)
+    full_roundtrip(Some(Option::<i32>::None)); // Some(None) — was the bug
+    full_roundtrip(Option::<i32>::None); // None
+    full_roundtrip(Some(Some(5_i32))); // unwrapped, clean
+    full_roundtrip(Some(Some(Option::<i32>::None))); // Some(Some(None))
+    full_roundtrip(vec![Some(Some(1_i32)), Some(None), None]);
 }


### PR DESCRIPTION
Addresses the nested-`Option` item in #68 (the Codex finding carried over from #67).

## Problem

`export` unwraps `Some` (no wrapper atom) and shares one `None` atom, so `Some(None)` and `None` were byte-identical in the graph — `from_datum::<Option<Option<T>>>(&export(&Some(None)))` reconstructed `None`.

## Fix

- **`export` (`serialize_some`):** keep unwrapping `Some(x)` by default (the common case stays a single clean atom, so `option_some_unwraps_to_inner_value` holds), but insert a `Some` wrapper atom **only when the inner serializes to a `None`/`Some`**. That makes `Some(None)` distinct from `None` and preserves arbitrary nesting, while every common case stays byte-identical — and it *improves* the diagram for the edge case (a `Some → None` edge instead of a bare `None`).
- **`reify` (`deserialize_option`):** descend through a `Some` wrapper via its `value` relation.
- **`from_datum` root-finding:** the `Some` wrapper is emitted *after* its inner, so the root is no longer `atoms[0]`. Switched to topology — the root is the atom that no relation targets — which is robust to emit order. (This is the topology root-finding noted under the `rootId` item in #68.)

## Tests

- `tests/reify.rs::nested_options_round_trip` — `Some(None)`, `Some(Some(None))`, `Some(Some(5))` (unwrapped), and a `Vec<Option<Option<i32>>>` all round-trip with R-eq + `{:?}` parity.
- `tests/export.rs::some_wraps_only_around_inner_none` — `Some(None)` produces a `Some` atom → `None`; plain `None` stays bare.
- Existing option/export tests unchanged and green. Full suite (22 export + 10 reify + 2 doc) green; clippy/fmt/doc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
