### PR TITLE
Round-trip i128/u128 and byte arrays; add serde data model coverage harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ test_output.html
 Thumbs.db
 
 macros/target/
+eval-corpus/target/
 
 # mdBook build output
 docs/book/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,17 @@ documentation = "https://docs.rs/spytial"
 homepage = "https://github.com/sidprasad/spytial-rust"
 keywords = ["spytial", "visualization", "diagram", "debugging", "graph"]
 categories = ["visualization", "development-tools"]
-exclude = ["target/", "Dockerfile", "docker-entrypoint.sh", ".github/", "docs/"]
+# `tests/serde_data_model.rs` is excluded because it depends on the unpublished
+# `spytial-eval-corpus` crate, which is not part of the package.
+exclude = [
+    "target/",
+    "Dockerfile",
+    "docker-entrypoint.sh",
+    ".github/",
+    "docs/",
+    "eval-corpus/",
+    "tests/serde_data_model.rs",
+]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -22,3 +32,8 @@ serde-value = "0.7"
 spytial_export_macros = { version = "0.2.0", path = "./macros" }
 
 [dev-dependencies]
+# Dev-only, unpublished, and outside this crate on purpose: the evaluation
+# corpus shared with ../reify-eval/rust.ipynb. Cargo permits this cycle
+# (eval-corpus depends on spytial) because dev-dependencies are not part of
+# the normal build graph.
+spytial-eval-corpus = { path = "./eval-corpus" }

--- a/eval-corpus/Cargo.toml
+++ b/eval-corpus/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "spytial-eval-corpus"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.80"
+description = "Shared value corpus for the cross-language Spytial reify evaluation. Not published."
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+spytial = { path = ".." }

--- a/eval-corpus/src/lib.rs
+++ b/eval-corpus/src/lib.rs
@@ -1,0 +1,436 @@
+//! Shared value corpus for the cross-language Spytial reify evaluation.
+//!
+//! One question, asked once per host language: does relationalizing a value
+//! preserve enough structure to reproduce the language's own inspection
+//! output? Rust exposes structure through `serde::Serialize`, so the shapes
+//! Spytial can possibly see are exactly the 29 types of the
+//! [serde data model](https://serde.rs/data-model.html). [`SERDE_DATA_MODEL`]
+//! names all 29; [`cases`] exercises each with concrete values; two oracles
+//! judge every case:
+//!
+//! * **R-eq** — `v == from_datum(export(v))`. The datum reconstructs the value.
+//! * **R-inspect** — `format!("{:?}", v) == replit(export(v))`. The datum
+//!   reproduces Rust's textual inspection output.
+//!
+//! This crate exists so its two consumers cannot drift apart:
+//! `../tests/serde_data_model.rs` enforces the corpus in CI, and
+//! `../../reify-eval/rust.ipynb` imports the very same crate to narrate the
+//! results. It is unpublished (`publish = false`) and deliberately outside the
+//! `spytial` crate, so evaluation machinery never reaches the published API.
+
+#![deny(missing_docs)]
+
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Debug;
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use spytial::export::try_export_json_instance;
+use spytial::{from_datum, replit};
+
+/// The serde data model: 29 types, the complete set of structural categories a
+/// `Serialize` impl can express. Every entry must appear in [`cases`] —
+/// `../tests/serde_data_model.rs` asserts exactly that.
+pub const SERDE_DATA_MODEL: [&str; 29] = [
+    "bool",
+    "i8",
+    "i16",
+    "i32",
+    "i64",
+    "i128",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
+    "u128",
+    "f32",
+    "f64",
+    "char",
+    "string",
+    "byte array",
+    "option",
+    "unit",
+    "unit_struct",
+    "unit_variant",
+    "newtype_struct",
+    "newtype_variant",
+    "seq",
+    "tuple",
+    "tuple_struct",
+    "tuple_variant",
+    "map",
+    "struct",
+    "struct_variant",
+];
+
+// ──────────────────────────────────────────────
+// Oracles
+// ──────────────────────────────────────────────
+
+/// Which oracles a case is expected to satisfy.
+///
+/// The two oracles have complementary blind spots, and the values that expose
+/// them are unrelated to the relational form: `HashMap` defeats R-inspect
+/// because its `{:?}` is iteration-order-dependent, `NaN` defeats R-eq because
+/// IEEE 754 makes `PartialEq` non-reflexive. Each is still checked by the other.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Support {
+    /// R-eq and R-inspect both hold.
+    Parity,
+    /// R-eq only — `{:?}` has no single correct rendering (`HashMap`).
+    EqOnly,
+    /// R-inspect only — the value is not `==` to itself (`NaN`).
+    InspectOnly,
+}
+
+impl Support {
+    /// One-character mark for compact tables: `=` both oracles, `e` R-eq only,
+    /// `i` R-inspect only.
+    pub fn mark(self) -> char {
+        match self {
+            Support::Parity => '=',
+            Support::EqOnly => 'e',
+            Support::InspectOnly => 'i',
+        }
+    }
+
+    /// Which oracle(s) apply, in words.
+    pub fn describe(self) -> &'static str {
+        match self {
+            Support::Parity => "both oracles",
+            Support::EqOnly => "R-eq only",
+            Support::InspectOnly => "R-inspect only",
+        }
+    }
+}
+
+/// One corpus entry: a value, the serde category it exercises, and the oracles
+/// it must satisfy.
+pub struct Case {
+    /// The serde data model category this case exercises — always one of
+    /// [`SERDE_DATA_MODEL`].
+    pub category: &'static str,
+    /// The value under test, as written in source.
+    pub expr: &'static str,
+    /// Which oracles apply.
+    pub support: Support,
+    /// Runs the applicable oracles, returning the reconstructed rendering on
+    /// success and a diagnostic on failure.
+    pub run: fn() -> Result<String, String>,
+}
+
+/// R-eq + R-inspect.
+pub fn parity<T>(v: T) -> Result<String, String>
+where
+    T: Serialize + DeserializeOwned + Debug + PartialEq,
+{
+    let datum = try_export_json_instance(&v).map_err(|e| format!("export failed: {e}"))?;
+    let back: T = from_datum(&datum).map_err(|e| format!("R-eq: from_datum failed: {e}"))?;
+    if back != v {
+        return Err(format!("R-eq: {:?} != {:?}", v, back));
+    }
+    let printed = replit::<T>(&datum).map_err(|e| format!("R-inspect: replit failed: {e}"))?;
+    let expected = format!("{:?}", v);
+    if printed != expected {
+        return Err(format!("R-inspect: expected {expected}, got {printed}"));
+    }
+    Ok(printed)
+}
+
+/// R-eq only — for containers whose `{:?}` is iteration-order-dependent.
+pub fn eq_only<T>(v: T) -> Result<String, String>
+where
+    T: Serialize + DeserializeOwned + Debug + PartialEq,
+{
+    let datum = try_export_json_instance(&v).map_err(|e| format!("export failed: {e}"))?;
+    let back: T = from_datum(&datum).map_err(|e| format!("R-eq: from_datum failed: {e}"))?;
+    if back != v {
+        return Err(format!("R-eq: {:?} != {:?}", v, back));
+    }
+    Ok(format!("{:?}", back))
+}
+
+/// R-inspect only — for values that are not `==` to themselves.
+pub fn inspect_only<T>(v: T) -> Result<String, String>
+where
+    T: Serialize + DeserializeOwned + Debug,
+{
+    let datum = try_export_json_instance(&v).map_err(|e| format!("export failed: {e}"))?;
+    let printed = replit::<T>(&datum).map_err(|e| format!("R-inspect: replit failed: {e}"))?;
+    let expected = format!("{:?}", v);
+    if printed != expected {
+        return Err(format!("R-inspect: expected {expected}, got {printed}"));
+    }
+    Ok(printed)
+}
+
+// ──────────────────────────────────────────────
+// Types exercising the compound categories
+// ──────────────────────────────────────────────
+
+/// Exercises `unit_struct`.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct UnitStruct;
+
+/// Exercises `newtype_struct`.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Meters(
+    /// The wrapped length.
+    pub f64,
+);
+
+/// Exercises `tuple_struct`.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Pair(
+    /// First component.
+    pub i32,
+    /// Second component.
+    pub i32,
+);
+
+/// Exercises `struct` with primitive fields.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Point {
+    /// Horizontal coordinate.
+    pub x: i32,
+    /// Vertical coordinate.
+    pub y: i32,
+}
+
+/// Exercises `struct` nesting.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Line {
+    /// Start point.
+    pub start: Point,
+    /// End point.
+    pub end: Point,
+}
+
+/// Exercises `struct` with no fields.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Empty {}
+
+/// Exercises all four enum variant shapes.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum Shape {
+    /// `unit_variant`.
+    Empty,
+    /// `newtype_variant`.
+    Radius(f64),
+    /// `tuple_variant`.
+    Offset(i32, i32),
+    /// `struct_variant`.
+    Rect {
+        /// Width.
+        w: i32,
+        /// Height.
+        h: i32,
+    },
+}
+
+/// A hand-written `Debug` — R-inspect has to reproduce this too, not just the
+/// derived form.
+#[derive(Serialize, Deserialize, PartialEq)]
+pub struct Temperature {
+    /// Degrees Celsius.
+    pub celsius: f64,
+}
+
+impl Debug for Temperature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}°C", self.celsius)
+    }
+}
+
+/// Exercises `byte array`: `Vec<u8>` serializes as a *seq* by default; only
+/// `serialize_bytes` reaches the byte-array category, which is what the
+/// `#[serde(with)]` shim forces.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Bytes(
+    /// The raw bytes.
+    #[serde(with = "byte_string")]
+    pub Vec<u8>,
+);
+
+mod byte_string {
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &[u8], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_bytes(v)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        use serde::de::{Error, Visitor};
+
+        struct ByteVisitor;
+
+        impl<'de> Visitor<'de> for ByteVisitor {
+            type Value = Vec<u8>;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a byte string")
+            }
+
+            fn visit_bytes<E: Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                Ok(v.to_vec())
+            }
+
+            fn visit_byte_buf<E: Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+                Ok(v)
+            }
+        }
+
+        d.deserialize_byte_buf(ByteVisitor)
+    }
+}
+
+// ──────────────────────────────────────────────
+// The cases
+// ──────────────────────────────────────────────
+
+/// Shorthand: `case!("i32", 42_i32)` → a [`Case`] whose `expr` is the literal
+/// source text, so coverage tables show what was actually tested.
+macro_rules! case {
+    ($category:literal, $value:expr) => {
+        Case {
+            category: $category,
+            expr: stringify!($value),
+            support: Support::Parity,
+            run: || parity($value),
+        }
+    };
+    ($category:literal, $value:expr, eq_only) => {
+        Case {
+            category: $category,
+            expr: stringify!($value),
+            support: Support::EqOnly,
+            run: || eq_only($value),
+        }
+    };
+    ($category:literal, $value:expr, inspect_only) => {
+        Case {
+            category: $category,
+            expr: stringify!($value),
+            support: Support::InspectOnly,
+            run: || inspect_only($value),
+        }
+    };
+}
+
+/// The corpus: concrete values covering every category in
+/// [`SERDE_DATA_MODEL`], including extremes (integer bounds, `-0.0`,
+/// infinities, `NaN`), quoting hazards, empty containers, nested options, and
+/// cross-category composition.
+pub fn cases() -> Vec<Case> {
+    vec![
+        // -- scalars ------------------------------------------------------
+        case!("bool", true),
+        case!("bool", false),
+        case!("i8", 0_i8),
+        case!("i8", i8::MIN),
+        case!("i8", i8::MAX),
+        case!("i16", i16::MIN),
+        case!("i16", i16::MAX),
+        case!("i32", 42_i32),
+        case!("i32", -7_i32),
+        case!("i32", i32::MIN),
+        case!("i64", i64::MIN),
+        case!("i64", i64::MAX),
+        case!("i128", 0_i128),
+        case!("i128", i128::MIN),
+        case!("i128", i128::MAX),
+        case!("u8", 0_u8),
+        case!("u8", u8::MAX),
+        case!("u16", u16::MAX),
+        case!("u32", u32::MAX),
+        case!("u64", u64::MAX),
+        case!("u128", 0_u128),
+        case!("u128", u128::MAX),
+        // -- floats: parsing the label must not perturb the bit pattern ---
+        case!("f32", -0.25_f32),
+        case!("f32", f32::MIN),
+        case!("f64", 3.0_f64),
+        case!("f64", 3.5_f64),
+        case!("f64", -0.0_f64),
+        case!("f64", f64::MIN_POSITIVE),
+        case!("f64", f64::INFINITY),
+        case!("f64", f64::NEG_INFINITY),
+        case!("f64", f64::NAN, inspect_only),
+        // -- text: labels are raw, so escaping is Debug's job, not ours ---
+        case!("char", 'z'),
+        case!("char", '💡'),
+        case!("char", '\n'),
+        case!("char", '\''),
+        case!("string", "hello".to_string()),
+        case!("string", String::new()),
+        case!("string", "a\"b\nc\\d".to_string()),
+        case!("string", "λ 💡 中文".to_string()),
+        case!("byte array", Bytes(vec![1, 2, 3])),
+        case!("byte array", Bytes(vec![])),
+        case!("byte array", Bytes(vec![0, 255])),
+        // -- option: the Some-wrapper rule (see export::serialize_some) ---
+        case!("option", Some(5_i32)),
+        case!("option", Option::<i32>::None),
+        case!("option", Some(Option::<i32>::None)),
+        case!("option", Some(Some(5_i32))),
+        case!("option", Some(Some(Option::<i32>::None))),
+        // -- nullary shapes: all interned as singletons -------------------
+        case!("unit", ()),
+        case!("unit_struct", UnitStruct),
+        case!("unit_variant", Shape::Empty),
+        // -- wrappers -----------------------------------------------------
+        case!("newtype_struct", Meters(2.5)),
+        case!("newtype_variant", Shape::Radius(1.5)),
+        case!("newtype_variant", Shape::Radius(f64::NAN), inspect_only),
+        // -- sequences: idx relations -------------------------------------
+        case!("seq", vec![1_i32, 2, 3]),
+        case!("seq", Vec::<i32>::new()),
+        case!("seq", vec![1_i32, 1, 1]),
+        case!("seq", vec![vec![1_i32], vec![], vec![2, 3]]),
+        case!("seq", vec![Some(1_i32), None, Some(3)]),
+        // -- tuples: fixed-size arrays serialize as tuples too ------------
+        case!("tuple", (1_i32, "x".to_string(), true)),
+        case!("tuple", (1_i32,)),
+        case!("tuple", [1_i32, 2, 3]),
+        case!("tuple_struct", Pair(3, 4)),
+        case!("tuple_variant", Shape::Offset(2, 3)),
+        // -- maps: BTreeMap has a deterministic {:?}, HashMap does not ----
+        case!("map", BTreeMap::from([("a".to_string(), 1_i32)])),
+        case!("map", BTreeMap::<String, i32>::new()),
+        case!("map", BTreeMap::from([(1_i32, vec!["x".to_string()])])),
+        case!(
+            "map",
+            HashMap::from([("a".to_string(), 1_i32), ("b".to_string(), 2)]),
+            eq_only
+        ),
+        // -- structs ------------------------------------------------------
+        case!("struct", Point { x: 1, y: 2 }),
+        case!("struct", Empty {}),
+        case!(
+            "struct",
+            Line {
+                start: Point { x: 1, y: 2 },
+                end: Point { x: 3, y: 4 },
+            }
+        ),
+        case!("struct", Temperature { celsius: 21.5 }),
+        case!("struct_variant", Shape::Rect { w: 10, h: 5 }),
+        // -- composition: categories nested inside each other -------------
+        case!(
+            "struct",
+            Point {
+                x: i32::MAX,
+                y: i32::MIN
+            }
+        ),
+        case!(
+            "seq",
+            vec![
+                Shape::Empty,
+                Shape::Radius(2.0),
+                Shape::Offset(1, 2),
+                Shape::Rect { w: 1, h: 1 },
+            ]
+        ),
+    ]
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -272,6 +272,10 @@ impl<'a> Serializer for &'a mut JsonDataSerializer {
         Ok(self.emit_atom("i64", &v.to_string()))
     }
 
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        Ok(self.emit_atom("i128", &v.to_string()))
+    }
+
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
         Ok(self.emit_atom("u8", &v.to_string()))
     }
@@ -286,6 +290,10 @@ impl<'a> Serializer for &'a mut JsonDataSerializer {
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
         Ok(self.emit_atom("u64", &v.to_string()))
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        Ok(self.emit_atom("u128", &v.to_string()))
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {

--- a/src/jsondata.rs
+++ b/src/jsondata.rs
@@ -6,7 +6,7 @@
 //! shape is what spytial-core consumes on the JavaScript side — these structs
 //! are part of the public, stable API.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A relational instance: the full set of atoms (nodes) and relations (edges)
 /// extracted from a single Rust value.
@@ -32,7 +32,7 @@ use serde::Serialize;
 /// [`export_json_instance`]: crate::export_json_instance
 /// [`from_datum`]: crate::from_datum
 /// [`from_datum_root`]: crate::from_datum_root
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct JsonDataInstance {
     /// All atoms (graph nodes), in serialization order — `atoms[0]` is the root
     /// (see the "Root atom" note on [`JsonDataInstance`]).
@@ -47,7 +47,7 @@ pub struct JsonDataInstance {
 /// tuple, map), and primitive leaves. `id` is unique within the instance,
 /// `type` is the Rust type name (e.g. `"Person"`, `"i32"`, `"sequence"`),
 /// and `label` is the human-readable text shown in the diagram.
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct IAtom {
     /// Unique identifier within the enclosing [`JsonDataInstance`].
     pub id: String,
@@ -59,7 +59,7 @@ pub struct IAtom {
 
 /// A single tuple within a relation: the participating atoms and the type
 /// of each position.
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct ITuple {
     /// Atom IDs in this tuple, in position order.
     pub atoms: Vec<String>,
@@ -72,7 +72,7 @@ pub struct ITuple {
 ///
 /// Examples: a field relation `name(Person, string)`, a sequence relation
 /// `idx(sequence, index, T)`, or a map relation `map_entry(map, K, V)`.
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct IRelation {
     /// Stable identifier for the relation (currently the same as [`Self::name`]).
     pub id: String,

--- a/src/reify.rs
+++ b/src/reify.rs
@@ -9,8 +9,9 @@
 //!
 //! # Scope
 //!
-//! Covers the full serde tree model: primitives, `Option`, sequences, tuples,
-//! tuple/newtype/unit structs, maps, structs, and all enum variant shapes. That
+//! Covers the full serde tree model: primitives (including `i128`/`u128`),
+//! byte arrays, `Option`, sequences, tuples, tuple/newtype/unit structs, maps,
+//! structs, and all enum variant shapes. That
 //! is exactly what [`crate::export`] produces, which is acyclic by construction
 //! — arena/index "graphs" round-trip as plain data (a self-loop is the integer
 //! index `Some(0)`, not a pointer). True `Rc<RefCell>` pointer cycles are not
@@ -311,10 +312,9 @@ impl<'i, 'a, 'de> Deserializer<'de> for NodeDeserializer<'i, 'a> {
         visitor.visit_string(a.label.clone())
     }
 
-    fn deserialize_bytes<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, ReifyError> {
-        Err(ReifyError::msg(
-            "bytes are not supported by spytial reify yet",
-        ))
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
+        let a = self.atom()?;
+        visitor.visit_byte_buf(parse_bytes_label(&a.label)?)
     }
 
     fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, ReifyError> {
@@ -607,6 +607,26 @@ impl<'i, 'a, 'de> VariantAccess<'de> for VariantWalker<'i, 'a> {
             pos: 0,
         })
     }
+}
+
+/// Parse the label `export` writes for a byte string: Rust's `{:?}` for a
+/// `&[u8]`, i.e. `[1, 2, 3]` or `[]`.
+fn parse_bytes_label(label: &str) -> Result<Vec<u8>, ReifyError> {
+    let inner = label
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .ok_or_else(|| ReifyError::msg(format!("malformed bytes label '{label}'")))?;
+    if inner.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    inner
+        .split(',')
+        .map(|b| {
+            b.trim()
+                .parse::<u8>()
+                .map_err(|e| ReifyError::msg(format!("bad byte in label '{label}': {e}")))
+        })
+        .collect()
 }
 
 /// Deserializer that yields a fixed string — used for struct field names and

--- a/tests/serde_data_model.rs
+++ b/tests/serde_data_model.rs
@@ -1,0 +1,94 @@
+//! CI driver for the shared serde-data-model corpus.
+//!
+//! The corpus itself lives in the unpublished `spytial-eval-corpus` crate
+//! (`./eval-corpus`): all 29 types of the
+//! [serde data model](https://serde.rs/data-model.html), concrete values for
+//! each, and the two oracles — **R-eq** (`v == from_datum(export(v))`) and
+//! **R-inspect** (`format!("{:?}", v) == replit(export(v))`). The literate
+//! report at `../reify-eval/rust.ipynb` depends on the very same crate, so this
+//! suite and that report cannot drift apart.
+//!
+//! Two tests: [`round_trip`] checks every case, [`coverage_is_total`] checks
+//! that every serde category has one. Run with `--nocapture` to print the
+//! coverage table.
+//!
+//! `tests/reify.rs` covers the same machinery from the other direction — it is
+//! organized by Rust-level shape and pins specific regressions. This corpus is
+//! organized by serde category and is the one that must stay exhaustive.
+
+use spytial_eval_corpus::{cases, SERDE_DATA_MODEL};
+
+#[test]
+fn round_trip() {
+    let cases = cases();
+    let mut failures: Vec<String> = Vec::new();
+    let mut rows: Vec<(&str, String, char, String)> = Vec::new();
+
+    for case in &cases {
+        // `stringify!` keeps the source's line breaks; the table wants one line.
+        let expr = case.expr.split_whitespace().collect::<Vec<_>>().join(" ");
+        match (case.run)() {
+            Ok(printed) => rows.push((case.category, expr, case.support.mark(), printed)),
+            Err(why) => {
+                failures.push(format!("[{}] {}: {}", case.category, expr, why));
+                rows.push((case.category, expr, '!', why));
+            }
+        }
+    }
+
+    print_table(&rows);
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} cases failed:\n  {}",
+        failures.len(),
+        cases.len(),
+        failures.join("\n  ")
+    );
+}
+
+/// Every serde category is exercised, and no case is filed under a category
+/// that is not in the data model. Guards the corpus against silently shrinking.
+#[test]
+fn coverage_is_total() {
+    let cases = cases();
+
+    let missing: Vec<&str> = SERDE_DATA_MODEL
+        .iter()
+        .copied()
+        .filter(|c| !cases.iter().any(|case| case.category == *c))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "serde data model categories with no case: {missing:?}"
+    );
+
+    let unknown: Vec<&str> = cases
+        .iter()
+        .map(|case| case.category)
+        .filter(|c| !SERDE_DATA_MODEL.contains(c))
+        .collect();
+    assert!(
+        unknown.is_empty(),
+        "cases filed under categories outside the serde data model: {unknown:?}"
+    );
+}
+
+/// Print the coverage table, in `SERDE_DATA_MODEL` order. Visible under
+/// `cargo test --test serde_data_model -- --nocapture`.
+fn print_table(rows: &[(&str, String, char, String)]) {
+    let width = rows.iter().map(|(_, e, _, _)| e.len()).max().unwrap_or(0);
+    println!(
+        "\nserde data model coverage  \
+         (= both oracles, e R-eq only, i R-inspect only, ! failed)\n"
+    );
+    for category in SERDE_DATA_MODEL {
+        let mut first = true;
+        for (_, expr, mark, printed) in rows.iter().filter(|(c, _, _, _)| *c == category) {
+            let label = if first { category } else { "" };
+            println!("  {label:<16} {mark} {expr:<width$}  {printed}");
+            first = false;
+        }
+    }
+    println!();
+}


### PR DESCRIPTION
## What

Closes two round-trip gaps in `export`/`reify`, and adds a corpus organized by the [Serde data model](https://serde.rs/data-model.html) so the coverage boundary is machine-checked rather than assumed.

## The two bugs

Both were hard errors, and both fixes are **strictly additive** — they turn failures into working output and change no existing behavior.

| Where | Before | After |
|---|---|---|
| `src/export.rs` | No `serialize_i128`/`serialize_u128`, so serde's default impl rejected every 128-bit integer with `"i128 is not supported"` | Emits an atom like every other integer width |
| `src/reify.rs` | `deserialize_bytes` returned `"bytes are not supported by spytial reify yet"` | Parses the `bytes` atom label `export` was **already writing** |

The bytes fix reads the existing label format, so `export` output and diagram rendering are untouched.

## Why a new harness

`tests/reify.rs` is organized by Rust-level shape and pins specific regressions — worth keeping as-is. But nothing was organized to answer *"which structural categories are covered?"*, which is how the two gaps above went unnoticed.

The serde data model's 29 types are, by construction, every structural category a `Serialize` impl can express — so enumerating them converts "we support the whole model" into a checkable claim:

- **`coverage_is_total`** fails if any of the 29 categories loses its cases, or if a case is filed under a category outside the model.
- **`round_trip`** runs 74 values through two oracles:
  - **R-eq** — `v == from_datum(export(v))`
  - **R-inspect** — `format!("{:?}", v) == replit(export(v))`

R-inspect is the load-bearing one. `replit` rebuilds a genuine `T` and runs the **real** `Debug` impl rather than formatting the datum, so parity means the relational form retained everything `{:?}` reads — including hand-written `Debug` impls (the corpus has a `Temperature` that prints `21.5°C`).

Values include the extremes: integer bounds out to `i128::MIN`/`u128::MAX`, `-0.0`, both infinities, `NaN`, quoting hazards, multi-byte chars, empty containers, nested options (`Some(Some(None))`), and cross-category composition.

## Two oracle exemptions

Each is a property of the *value*, not of the relational form, and each is still checked by the other oracle:

- `HashMap` is **R-eq only** — its `{:?}` is iteration-order-dependent, so no single string is the correct rendering.
- `NaN` is **R-inspect only** — IEEE 754 makes `==` non-reflexive, so R-eq is ill-posed.

## Reviewer notes

- **The corpus is in a separate unpublished crate** (`eval-corpus/`, `publish = false`, wired in as a dev-dependency) specifically so no evaluation machinery reaches the published API. Cargo permits the resulting dev-dependency cycle since dev-deps aren't in the normal build graph. `tests/serde_data_model.rs` is added to `exclude` because it depends on that crate; `cargo package` verifies clean.
- **`jsondata` types gain `Deserialize`.** This is a public API addition. It makes a datum readable back from JSON — previously impossible — and is what lets a consumer prove reconstruction reads pure relational data rather than a live Rust value that hitched a ride.
- `.gitignore` gains `eval-corpus/target/`, matching the existing `macros/target/` entry (root `/target/` is anchored and wouldn't cover it).
- The corpus is shared with a literate notebook (`reify-eval/rust.ipynb`) that narrates these results; that directory isn't under version control, so it's outside this PR. Both depend on the same crate so the report and this suite cannot drift.

## Verification

`cargo test` 74 passing across all 8 targets · `cargo clippy --all-targets` clean (both crates) · `cargo fmt --all --check` clean · `cargo package` verifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)