### PR TITLE
Decouple the eval corpus from the spytial crate's build graph

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Run doc tests
         run: cargo test --doc
 
+      # Its own workspace, so the run above does not reach it.
+      - name: Run eval-corpus tests
+        run: cargo test --manifest-path eval-corpus/Cargo.toml
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -54,3 +58,7 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+      # Its own workspace, so the check above does not reach it.
+      - name: Check eval-corpus formatting
+        run: cargo fmt --manifest-path eval-corpus/Cargo.toml --all -- --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,13 @@ cargo test --lib --tests
 cargo test --doc
 ```
 
+The serde-data-model corpus in `eval-corpus/` is a separate workspace, so the
+commands above do not reach it. Run its tests directly:
+
+```sh
+cargo test --manifest-path eval-corpus/Cargo.toml
+```
+
 ## Running examples
 
 ```sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ documentation = "https://docs.rs/spytial"
 homepage = "https://github.com/sidprasad/spytial-rust"
 keywords = ["spytial", "visualization", "diagram", "debugging", "graph"]
 categories = ["visualization", "development-tools"]
-# `tests/serde_data_model.rs` is excluded because it depends on the unpublished
-# `spytial-eval-corpus` crate, which is not part of the package.
 exclude = [
     "target/",
     "Dockerfile",
@@ -21,7 +19,6 @@ exclude = [
     ".github/",
     "docs/",
     "eval-corpus/",
-    "tests/serde_data_model.rs",
 ]
 
 [dependencies]
@@ -30,10 +27,3 @@ serde_json = "1.0"
 serde_yaml_ng = "0.10"
 serde-value = "0.7"
 spytial_export_macros = { version = "0.2.0", path = "./macros" }
-
-[dev-dependencies]
-# Dev-only, unpublished, and outside this crate on purpose: the evaluation
-# corpus shared with ../reify-eval/rust.ipynb. Cargo permits this cycle
-# (eval-corpus depends on spytial) because dev-dependencies are not part of
-# the normal build graph.
-spytial-eval-corpus = { path = "./eval-corpus" }

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -14,6 +14,8 @@ cargo build
 cargo test --lib --tests
 cargo test --doc
 cargo run --example rbt          # add SPYTIAL_NO_OPEN=1 to skip the browser
+
+cargo test --manifest-path eval-corpus/Cargo.toml   # separate workspace
 ```
 
 ## Before opening a PR

--- a/eval-corpus/Cargo.toml
+++ b/eval-corpus/Cargo.toml
@@ -1,3 +1,9 @@
+# Its own workspace root, deliberately: `spytial` must not depend on the corpus
+# in any way, not even as a dev-dependency, so that building or packaging the
+# crate never needs this directory. The arrow points one way only — the corpus
+# depends on `spytial`, and its tests run from here.
+[workspace]
+
 [package]
 name = "spytial-eval-corpus"
 version = "0.0.0"

--- a/eval-corpus/tests/serde_data_model.rs
+++ b/eval-corpus/tests/serde_data_model.rs
@@ -1,20 +1,23 @@
 //! CI driver for the shared serde-data-model corpus.
 //!
-//! The corpus itself lives in the unpublished `spytial-eval-corpus` crate
-//! (`./eval-corpus`): all 29 types of the
+//! The corpus itself is this crate's `src/lib.rs`: all 29 types of the
 //! [serde data model](https://serde.rs/data-model.html), concrete values for
 //! each, and the two oracles — **R-eq** (`v == from_datum(export(v))`) and
 //! **R-inspect** (`format!("{:?}", v) == replit(export(v))`). The literate
-//! report at `../reify-eval/rust.ipynb` depends on the very same crate, so this
-//! suite and that report cannot drift apart.
+//! report at `../../reify-eval/rust.ipynb` depends on the very same crate, so
+//! this suite and that report cannot drift apart.
+//!
+//! The suite lives here rather than in `spytial`'s own `tests/` so that
+//! `spytial` needs nothing from this directory to build, test, or package.
 //!
 //! Two tests: [`round_trip`] checks every case, [`coverage_is_total`] checks
 //! that every serde category has one. Run with `--nocapture` to print the
 //! coverage table.
 //!
-//! `tests/reify.rs` covers the same machinery from the other direction — it is
-//! organized by Rust-level shape and pins specific regressions. This corpus is
-//! organized by serde category and is the one that must stay exhaustive.
+//! `spytial`'s `tests/reify.rs` covers the same machinery from the other
+//! direction — it is organized by Rust-level shape and pins specific
+//! regressions. This corpus is organized by serde category and is the one that
+//! must stay exhaustive.
 
 use spytial_eval_corpus::{cases, SERDE_DATA_MODEL};
 


### PR DESCRIPTION
## What & why

The main-branch Docker build [failed](https://github.com/sidprasad/spytial-rust/actions/runs/29742270853) after #76. That PR added `spytial-eval-corpus` as a path **dev-dependency**, but the Dockerfile copies a hand-picked file list into the builder stage and never included `eval-corpus/`. `cargo build --examples` pulls dev-dependencies into the build graph, so it failed to resolve the corpus:

```
error: failed to get `spytial-eval-corpus` as a dependency of package `spytial v0.2.0 (/app)`
  No such file or directory (os error 2)
```

The corpus is a **test fixture** — the shared serde-data-model value set — not something spytial's core build should depend on. So instead of teaching the Dockerfile about it, this PR severs the edge.

Why not just mark it optional? Cargo won't let you: `optional` is rejected in `[dev-dependencies]`, and building examples compiles dev-deps regardless. The decoupling has to be structural.

## What changed

- **Moved the only consumer** `tests/serde_data_model.rs` → `eval-corpus/tests/serde_data_model.rs`. It used `spytial_eval_corpus`, never `spytial` directly, so it moved essentially unchanged (doc-comment paths only).
- **Dropped `spytial`'s `[dev-dependencies]` on the corpus.** The dependency arrow now points one way: corpus → spytial.
- **Made `eval-corpus` its own workspace root** (`[workspace]`), required once it's no longer reachable as a path dep.
- **Removed the `tests/serde_data_model.rs` exclude** from `Cargo.toml` — packaging no longer needs to know the corpus exists.
- **Wired the corpus into CI** — a separate workspace is invisible to root-level cargo, so `pr.yml` now runs `cargo test` and `cargo fmt --check` against `eval-corpus/Cargo.toml` explicitly, and `CONTRIBUTING.md` / the docs note the extra command.

The **Dockerfile is untouched.**

## Verification

Docker's daemon wasn't running locally, so for the image build I staged a directory containing exactly the files the Dockerfile copies (no `eval-corpus/`):

- Staged Docker context builds clean (`cargo build --release --examples --bin viz_server`) — the CI failure is fixed at the source.
- `cargo build --all-targets` + `--locked`, root `cargo test --lib --tests` (7 suites), and corpus `cargo test` (`round_trip`, `coverage_is_total`) all pass.
- `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean in **both** workspaces.
- `cargo package` succeeds; packaged crate contents are byte-identical to before (that test was already excluded).

## Reviewer notes

- No CHANGELOG entry: the published crate is unchanged.
- Follow-up worth considering (not in this PR): add a no-push `docker build` job to `pr.yml` so image breakage is caught at PR time rather than after merge to main — this class of failure is currently invisible to PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)