### PR TITLE
Warn on the forms spytial-core has deprecated

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Run doc tests
         run: cargo test --doc
 
+      # `macros` is a path dependency, not a workspace member, so the runs above
+      # do not reach it and `--workspace` would not help. `--lib` only: its doc
+      # example needs `spytial`, which it cannot depend on without a cycle.
+      - name: Run derive-macro unit tests
+        run: cargo test --manifest-path macros/Cargo.toml --lib
+
       # Its own workspace, so the run above does not reach it.
       - name: Run eval-corpus tests
         run: cargo test --manifest-path eval-corpus/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Deprecated forms now warn at compile time:
+
+- Every form spytial-core marks deprecated produces a `deprecated` warning
+  naming the replacement and how its fields map across. The text is generated
+  from the manifest's `deprecations[]`, so it moves when upstream's does.
+  Nothing stops compiling and no behaviour changes — the deprecated forms are
+  still parsed and rewritten exactly as before.
+- The warning is keyed on the form, not the attribute, because two of them are
+  a deprecated *shape* of an attribute that is otherwise current:
+  `#[group(field = ...)]` warns and `#[group(selector = ...)]` does not;
+  `#[edge_style(value = ...)]` warns and the `line_style(...)` block form does
+  not. A bare `#[edge_style(field = "x")]` also stays quiet: it carries no
+  deprecated key, and the legacy path it takes is this crate's own blue
+  default rather than something the user asked for.
+- `#[allow(deprecated)]` on the type silences it. The expansion copies the
+  type's `allow`/`expect` attributes onto the generated marker, because that
+  marker is a sibling item — without the copy the only way to quiet one legacy
+  attribute would be `#![allow(deprecated)]` over the whole module.
+- This closes a gap in the tables added below: `AttrSpec::deprecated_for` was
+  generated correctly and never read, so the deprecation data was extracted
+  from the manifest and then dropped. `#[group(field = ...)]` had no signal at
+  all, because deprecation was recorded per attribute and `#[group]` merges a
+  deprecated manifest item with a current one.
+- spec-codegen fails the build if spytial-core deprecates something new that is
+  neither warned about nor listed in `DEPRECATIONS_NOT_APPLICABLE` with a
+  reason, and if a listed exemption goes stale. Wire-section placements and the
+  inline `inferredEdge` fields are exempt: the macro never offered them.
+- CI now runs the derive macro's own unit tests. It is a path dependency rather
+  than a workspace member, so `cargo test` at the root never reached it and
+  `--workspace` does not either; it needs its own `--manifest-path` step, like
+  `eval-corpus` and `spec-codegen`.
+
 The derive macro's accepted keys and compile-time validation are now generated
 from spytial-core's own language manifest instead of transcribed by hand:
 

--- a/docs/src/decorators.md
+++ b/docs/src/decorators.md
@@ -184,6 +184,25 @@ filled look), and `edge_style`'s `value`/`style`/`weight` become
 `line_style`'s `color`/`pattern`/`weight`. Mixing flat keys and blocks in one
 `edge_style` is a compile error.
 
+**Deprecation warnings:** every form spytial-core has deprecated now warns at
+compile time, naming the replacement and how the fields map across. That covers
+whole attributes (`#[atom_color]`, `#[icon]`) and single shapes of attributes
+that are otherwise current — `#[group(field = ...)]` warns while
+`#[group(selector = ...)]` does not, and `#[edge_style(value = ...)]` warns
+while `#[edge_style(field = ..., line_style(...))]` does not. Nothing stops
+compiling; the deprecated forms still work exactly as before. To keep one
+deliberately, put `#[allow(deprecated)]` on the type:
+
+```rust,ignore
+#[derive(Serialize, SpytialDecorators)]
+#[allow(deprecated)]
+#[atom_color(selector = "Node", value = "red")]
+struct Node { /* ... */ }
+```
+
+The warning text comes from spytial-core's own language manifest, so it moves
+when upstream's does.
+
 > **Breaking in spytial-core 3.0:** two style rules that set the same property
 > of the same edge/atom to *different* values now raise a
 > `StyleCollisionError` at render time (2.x silently kept the first). Set each

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,11 +1,12 @@
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::{
-    parse_macro_input, Attribute, Data, DeriveInput, Fields, GenericArgument, PathArguments, Type,
+    parse_macro_input, spanned::Spanned, Attribute, Data, DeriveInput, Fields, GenericArgument,
+    PathArguments, Type,
 };
 
 mod spec_tables;
-use spec_tables::FieldRule;
+use spec_tables::{DeprecationSpec, FieldRule};
 
 /// Emit a decorator-probe call for each distinct user type reachable through
 /// this type's fields (looking through containers like `Vec`/`Option`/`Box`).
@@ -176,12 +177,37 @@ pub fn derive_spytial_decorators(input: TokenStream) -> TokenStream {
 
     // Parse spatial annotation attributes for this type
     let mut decorator_calls = Vec::new();
+    let mut deprecation_shims = Vec::new();
+
+    // Suppressing lint attributes the user wrote on the type, copied onto every
+    // deprecation shim below.
+    //
+    // A shim is a sibling item of the struct, not part of it, so a plain
+    // `#[allow(deprecated)]` on the struct does not reach it — without this the
+    // only way to quiet one legacy attribute would be `#![allow(deprecated)]`
+    // over the whole module, which also hides every unrelated deprecation in
+    // it. Escalation needs no help: a module- or crate-level `deny` already
+    // covers the shim, because the module *is* its lint parent.
+    let lint_attrs: Vec<&Attribute> = input
+        .attrs
+        .iter()
+        .filter(|a| a.path().is_ident("allow") || a.path().is_ident("expect"))
+        .collect();
 
     for attr in &input.attrs {
         let parsed = match parse_spatial_attribute(attr) {
             Ok(parsed) => parsed,
             Err(err) => return err.to_compile_error().into(),
         };
+        // Only after a clean parse: a malformed attribute should report the
+        // error it has, not a deprecation notice on top of it.
+        if parsed.is_some() {
+            if let Some(name) = attr.path().get_ident().map(|i| i.to_string()) {
+                if let Some(shim) = deprecation_shim(attr, &name) {
+                    deprecation_shims.push(quote! { #(#lint_attrs)* #shim });
+                }
+            }
+        }
         match parsed {
             Some(SpatialAttribute::Attribute {
                 field,
@@ -428,6 +454,8 @@ pub fn derive_spytial_decorators(input: TokenStream) -> TokenStream {
 
     // Generate the HasSpytialDecorators implementation
     let expanded = quote! {
+        #(#deprecation_shims)*
+
         impl #impl_generics spytial::spytial_annotations::HasSpytialDecorators for #name #ty_generics #where_clause {
             fn decorators() -> spytial::spytial_annotations::SpytialDecorators {
                 // Register this type automatically when decorators() is called
@@ -594,6 +622,92 @@ fn parse_spatial_attribute(attr: &Attribute) -> Result<Option<SpatialAttribute>,
     } else {
         Ok(None)
     }
+}
+
+/// The deprecation that applies to this attribute *as written*, and the key
+/// that selected it.
+///
+/// A shape-scoped entry only fires when one of its keys is actually present.
+/// That is the whole point: `#[group(field = ...)]` is the deprecated form and
+/// `#[group(selector = ...)]` is the current one, so keying the warning on the
+/// attribute name alone would condemn both. Keys are read from the
+/// group-stripped token string for the same reason the parsers do — a `value`
+/// inside `line_style(...)` is not the legacy top-level `value`.
+fn deprecation_for(
+    attr: &Attribute,
+    attr_name: &str,
+) -> Option<(&'static DeprecationSpec, Option<&'static str>)> {
+    let stripped = attr
+        .meta
+        .require_list()
+        .ok()
+        .map(|meta| strip_groups(&meta.tokens.to_string()));
+
+    spec_tables::DEPRECATIONS.iter().find_map(|dep| {
+        if dep.attr != attr_name {
+            return None;
+        }
+        if dep.when_any_key.is_empty() {
+            return Some((dep, None));
+        }
+        let tokens = stripped.as_deref()?;
+        dep.when_any_key
+            .iter()
+            .find(|key| has_key(tokens, key))
+            .map(|key| (dep, Some(*key)))
+    })
+}
+
+/// An item that makes rustc emit a deprecation warning pointing at `attr`.
+///
+/// Proc macros cannot raise warnings directly on stable, so the expansion
+/// carries a `#[deprecated]` type and immediately uses it. Every token is
+/// spanned to the user's attribute, which is what puts the diagnostic on their
+/// `#[icon(...)]` rather than somewhere inside generated code.
+///
+/// The marker's name is part of the diagnostic — rustc prints "use of
+/// deprecated struct `_::icon_is_deprecated`" ahead of the note — so it is
+/// spelled to read as a sentence. Each shim gets its own anonymous const, so
+/// two identical deprecated attributes on one struct do not collide.
+fn deprecation_shim(attr: &Attribute, attr_name: &str) -> Option<proc_macro2::TokenStream> {
+    let (dep, matched) = deprecation_for(attr, attr_name)?;
+
+    let form = match matched {
+        Some(key) => format!("`#[{}({key} = ...)]`", dep.attr),
+        None => format!("`#[{}]`", dep.attr),
+    };
+    // A deprecated *shape* is replaced by another shape of the same attribute,
+    // so "use `#[group]`" would read as a no-op. Name the form instead.
+    let replacement = if dep.attr == dep.replaced_by {
+        format!("use the current form of `#[{}]`", dep.replaced_by)
+    } else {
+        format!("use `#[{}]`", dep.replaced_by)
+    };
+    let note = format!(
+        "{form} is deprecated in spytial-core {}; {replacement}. {}",
+        spec_tables::SPYTIAL_CORE_VERSION,
+        dep.note,
+    );
+
+    let span = attr.span();
+    let marker = syn::Ident::new(
+        &match matched {
+            Some(key) => format!("{}_{key}_form_is_deprecated", dep.attr),
+            None => format!("{}_is_deprecated", dep.attr),
+        },
+        span,
+    );
+    Some(quote_spanned! {span=>
+        const _: () = {
+            #[deprecated(note = #note)]
+            #[allow(non_camel_case_types)]
+            struct #marker;
+            // The use site. `allow(dead_code)` because nothing calls it — the
+            // reference in the signature is the entire point.
+            #[allow(dead_code)]
+            fn probe(_: #marker) {}
+        };
+    })
 }
 
 /// The generated spec for `attr_name`.
@@ -2189,4 +2303,160 @@ fn extract_array_from_tokens(tokens: &str, key: &str) -> Option<Vec<String>> {
         }
         Some(items)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    fn dep_for(
+        attr: Attribute,
+        name: &str,
+    ) -> Option<(&'static DeprecationSpec, Option<&'static str>)> {
+        deprecation_for(&attr, name)
+    }
+
+    /// One attribute, two shapes, one of them deprecated. Keying the warning on
+    /// the attribute name alone would condemn the current form too.
+    #[test]
+    fn only_the_deprecated_group_shape_warns() {
+        let (dep, key) = dep_for(
+            parse_quote!(#[group(field = "rel", group_on = 1, add_to_group = 0)]),
+            "group",
+        )
+        .expect("the field-based group is deprecated upstream");
+        assert_eq!(key, Some("field"));
+        assert_eq!(dep.replaced_by, "group");
+
+        assert!(
+            dep_for(
+                parse_quote!(#[group(selector = "Team.members", name = "Team")]),
+                "group"
+            )
+            .is_none(),
+            "the selector-based group is the current form and must stay quiet",
+        );
+    }
+
+    /// `icon` and `atom_color` are deprecated outright — every spelling warns.
+    #[test]
+    fn wholly_deprecated_attributes_warn_on_any_spelling() {
+        for attr in [
+            parse_quote!(#[icon(path = "a.svg")]),
+            parse_quote!(#[icon(selector = "P", path = "a.svg", show_labels = true)]),
+        ] {
+            let (dep, key) = dep_for(attr, "icon").expect("icon is deprecated");
+            assert_eq!(
+                key, None,
+                "no key selects it; the attribute itself is deprecated"
+            );
+            assert_eq!(dep.replaced_by, "atom_style");
+        }
+
+        let (dep, _) = dep_for(
+            parse_quote!(#[atom_color(selector = "N", value = "red")]),
+            "atom_color",
+        )
+        .expect("atom_color is deprecated");
+        assert_eq!(dep.replaced_by, "atom_style");
+    }
+
+    /// The legacy flat trio warns; the block form it was replaced by does not.
+    #[test]
+    fn legacy_edge_keys_warn_but_the_block_form_does_not() {
+        for (attr, expected) in [
+            (
+                parse_quote!(#[edge_style(field = "n", value = "blue")]),
+                "value",
+            ),
+            (
+                parse_quote!(#[edge_style(field = "n", style = "dotted")]),
+                "style",
+            ),
+            (
+                parse_quote!(#[edge_style(field = "n", weight = 2.0)]),
+                "weight",
+            ),
+        ] {
+            let (_, key) = dep_for(attr, "edge_style").expect("legacy flat keys are deprecated");
+            assert_eq!(key, Some(expected));
+        }
+
+        assert!(
+            dep_for(
+                parse_quote!(#[edge_style(field = "n", line_style(color = "blue"))]),
+                "edge_style"
+            )
+            .is_none(),
+            "the block form is current",
+        );
+    }
+
+    /// A legacy key name appearing *inside* a style block is not a legacy key.
+    /// Without the group-stripping this would warn on the current form.
+    #[test]
+    fn a_leaf_inside_a_block_is_not_a_top_level_legacy_key() {
+        assert!(
+            dep_for(
+                parse_quote!(#[edge_style(field = "n", line_style(weight = 2.0, pattern = "dotted"))]),
+                "edge_style"
+            )
+            .is_none(),
+            "`weight` inside line_style(...) is the block's leaf, not the legacy flat key",
+        );
+    }
+
+    /// The expansion has to be an actual `#[deprecated]` item carrying the
+    /// manifest's note — that item is the only reason rustc says anything.
+    #[test]
+    fn the_shim_is_a_deprecated_item_carrying_the_note() {
+        let attr: Attribute = parse_quote!(#[icon(path = "a.svg")]);
+        let shim = deprecation_shim(&attr, "icon")
+            .expect("icon is deprecated")
+            .to_string();
+
+        assert!(
+            shim.contains("deprecated"),
+            "not a deprecation shim:\n{shim}"
+        );
+        assert!(
+            shim.contains("icon_is_deprecated"),
+            "marker name is part of the diagnostic:\n{shim}"
+        );
+        assert!(
+            shim.contains("atom_style"),
+            "the note must name the replacement:\n{shim}"
+        );
+        assert!(
+            shim.contains(spec_tables::SPYTIAL_CORE_VERSION),
+            "the note must say which spytial-core deprecated it:\n{shim}",
+        );
+    }
+
+    /// A `when_any_key` naming a key the attribute does not accept, or a
+    /// `replaced_by` naming an attribute that does not exist, would produce a
+    /// warning that can never fire or that points nowhere. Neither is visible
+    /// at generation time, because both tables are generated independently.
+    #[test]
+    fn every_deprecation_refers_to_keys_and_attributes_that_exist() {
+        for dep in spec_tables::DEPRECATIONS {
+            let spec = spec_tables::attr_spec(dep.attr)
+                .unwrap_or_else(|| panic!("`{}` is not an authoring attribute", dep.attr));
+            for key in dep.when_any_key {
+                assert!(
+                    spec.keys.contains(key),
+                    "#[{}] is said to be deprecated when `{key}` is present, but it does not \
+                     accept that key — the warning could never fire",
+                    dep.attr,
+                );
+            }
+            assert!(
+                spec_tables::attr_spec(dep.replaced_by).is_some(),
+                "#[{}] points at `{}` as its replacement, which is not an authoring attribute",
+                dep.attr,
+                dep.replaced_by,
+            );
+        }
+    }
 }

--- a/macros/src/spec_tables.rs
+++ b/macros/src/spec_tables.rs
@@ -84,6 +84,26 @@ impl AttrSpec {
     }
 }
 
+/// A form spytial-core has deprecated, lowered to what the macro can warn about.
+///
+/// Not the same thing as [`AttrSpec::deprecated_for`]: that says the whole
+/// attribute is deprecated, which is only true when the attribute has exactly
+/// one manifest source. `#[group]` and `#[edge_style]` are current attributes
+/// with one deprecated *shape* each, and the shape is chosen by which keys the
+/// user wrote — so the warning has to be keyed on that, not on the attribute.
+#[derive(Debug)]
+pub struct DeprecationSpec {
+    /// The Rust authoring attribute the warning fires on.
+    pub attr: &'static str,
+    /// Rust keys whose presence selects the deprecated shape. Empty means the
+    /// attribute is deprecated outright, whatever it is written with.
+    pub when_any_key: &'static [&'static str],
+    /// The replacement, spelled as the Rust attribute to reach for.
+    pub replaced_by: &'static str,
+    /// spytial-core's own reason and field mapping, for the warning note.
+    pub note: &'static str,
+}
+
 /// One nested style block, e.g. `line_style(...)`.
 #[derive(Debug)]
 pub struct BlockSpec {
@@ -1118,6 +1138,14 @@ pub static BLOCKS: &[BlockSpec] = &[
             },
         ],
     },
+];
+
+/// Forms spytial-core has deprecated, in the order the manifest lists them.
+pub static DEPRECATIONS: &[DeprecationSpec] = &[
+    DeprecationSpec { attr: "group", when_any_key: &["field"], replaced_by: "group", note: "A binary selector whose first column is the key and whose second is the members says the same thing without tuple indices. Mapping: add_to_group -> selector (column order); field -> selector; group_on -> selector (column order). To migrate: over `worksIn: Employee -> Department`, `groupOn: 1` / `addToGroup: 0` keys on Department, so it becomes `selector: ~worksIn` plus the `name` that form requires." },
+    DeprecationSpec { attr: "icon", when_any_key: &[], replaced_by: "atom_style", note: "The single `showLabels` boolean drove label visibility and icon geometry at once. atomStyle splits those into two independent knobs, which is what makes a faded watermark, or a hidden label with no icon, expressible. Mapping: path -> icon_style.path; show_labels: false -> show_label: false + icon_style.placement: full; show_labels: true -> show_label: true + icon_style.placement: badge." },
+    DeprecationSpec { attr: "atom_color", when_any_key: &[], replaced_by: "atom_style", note: "atomStyle expresses the same recolor and also reaches the fill, the icon, and the label. The rewrite is border-preserving, so an existing diagram is unchanged. Mapping: value -> border_style.color." },
+    DeprecationSpec { attr: "edge_style", when_any_key: &["value", "style", "weight"], replaced_by: "edge_style", note: "edgeStyle groups the same knobs into the shared lineStyle/textStyle blocks that every other form uses. Mapping: highlight -> line_style.highlight; style -> line_style.pattern; value -> line_style.color; weight -> line_style.weight." },
 ];
 
 /// Direction pairs `orientation` rejects together (`above` with `below`,

--- a/spec-codegen/src/lib.rs
+++ b/spec-codegen/src/lib.rs
@@ -108,6 +108,55 @@ const FIELD_SKIPS: &[(&str, &str)] = &[
     ("edgeColor", "hidden"),
 ];
 
+/// How to tell a deprecated *shape* apart from a current one, when the manifest
+/// does not say and the two share a Rust attribute.
+///
+/// `group.byField` needs no entry — the manifest gives it a `discriminator`.
+/// `edgeColor` does not have one, because in YAML it is its own key; it is only
+/// a shape here because the Rust attribute merges it into `#[edge_style]`. The
+/// keys below are exactly the legacy flat trio `parse_edge_style_args` reads.
+///
+/// A bare `#[edge_style(field = "x")]` deliberately does *not* list: it carries
+/// no deprecated key, and the legacy path it takes is this crate's own blue
+/// default, not something the user asked for.
+///
+/// (manifest deprecation id, Rust keys whose presence selects the deprecated shape)
+const SHAPE_DISCRIMINATORS: &[(&str, &[&str])] = &[("edgeColor", &["value", "style", "weight"])];
+
+/// Manifest deprecations that cannot reach the Rust authoring surface, and why.
+///
+/// Like [`UNMAPPED_ITEMS`], this exists so silence is never the answer: every
+/// entry in the manifest's `deprecations[]` is either warned about or listed
+/// here. A spytial-core release that deprecates something new fails the build
+/// until someone decides which it is.
+const DEPRECATIONS_NOT_APPLICABLE: &[(&str, &str)] = &[
+    (
+        "size@directives",
+        "a wire-section placement, not an authoring form; the crate emits size \
+         under constraints already",
+    ),
+    (
+        "hideAtom@directives",
+        "likewise a placement; hideAtom is emitted under constraints",
+    ),
+    (
+        "inferredEdge.color",
+        "in FIELD_SKIPS — the macro never accepted the inline key",
+    ),
+    (
+        "inferredEdge.style",
+        "in FIELD_SKIPS — the macro never accepted the inline key",
+    ),
+    (
+        "inferredEdge.weight",
+        "in FIELD_SKIPS — the macro never accepted the inline key",
+    ),
+    (
+        "inferredEdge.highlight",
+        "in FIELD_SKIPS — the macro never accepted the inline key",
+    ),
+];
+
 fn camel_to_snake(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 4);
     for (i, c) in s.chars().enumerate() {
@@ -361,6 +410,26 @@ impl AttrSpec {{
     }}
 }}
 
+/// A form spytial-core has deprecated, lowered to what the macro can warn about.
+///
+/// Not the same thing as [`AttrSpec::deprecated_for`]: that says the whole
+/// attribute is deprecated, which is only true when the attribute has exactly
+/// one manifest source. `#[group]` and `#[edge_style]` are current attributes
+/// with one deprecated *shape* each, and the shape is chosen by which keys the
+/// user wrote — so the warning has to be keyed on that, not on the attribute.
+#[derive(Debug)]
+pub struct DeprecationSpec {{
+    /// The Rust authoring attribute the warning fires on.
+    pub attr: &'static str,
+    /// Rust keys whose presence selects the deprecated shape. Empty means the
+    /// attribute is deprecated outright, whatever it is written with.
+    pub when_any_key: &'static [&'static str],
+    /// The replacement, spelled as the Rust attribute to reach for.
+    pub replaced_by: &'static str,
+    /// spytial-core's own reason and field mapping, for the warning note.
+    pub note: &'static str,
+}}
+
 /// One nested style block, e.g. `line_style(...)`.
 #[derive(Debug)]
 pub struct BlockSpec {{
@@ -499,6 +568,128 @@ pub fn block_spec(block: &str) -> Option<&'static BlockSpec> {{
 
     s.push_str("/// Every nested style block the derive macro accepts.\npub static BLOCKS: &[BlockSpec] = &[\n");
     s.push_str(&block_entries.join("\n"));
+    s.push_str("\n];\n\n");
+
+    // ---- DEPRECATIONS ----
+    //
+    // Generated from the manifest's own `deprecations[]` so the note text moves
+    // when spytial-core's does. Only `kind: "item"` entries can reach the Rust
+    // authoring surface at all; placements and inline fields belong in
+    // DEPRECATIONS_NOT_APPLICABLE with the reason.
+    let no_deps = Vec::new();
+    let deprecations = man["deprecations"].as_array().unwrap_or(&no_deps);
+    let mut dep_entries = Vec::new();
+    for dep in deprecations {
+        let id = dep["id"].as_str().unwrap_or_default();
+        if DEPRECATIONS_NOT_APPLICABLE.iter().any(|(d, _)| *d == id) {
+            continue;
+        }
+        let kind = dep["kind"].as_str().unwrap_or("?");
+        if kind != "item" {
+            return Err(format!(
+                "manifest deprecation `{id}` is a `{kind}`, which the derive macro has no way to \
+                 warn about, and it is not listed in DEPRECATIONS_NOT_APPLICABLE in \
+                 spec-codegen/src/lib.rs."
+            ));
+        }
+
+        let Some((attr, sources)) = ATTR_SOURCES.iter().find(|(_, s)| s.contains(&id)) else {
+            return Err(format!(
+                "manifest deprecates item `{id}`, which no Rust attribute is authored from and \
+                 which is not in DEPRECATIONS_NOT_APPLICABLE in spec-codegen/src/lib.rs."
+            ));
+        };
+        let item = find_item(id)
+            .ok_or_else(|| format!("manifest deprecates `{id}` but describes no such item"))?;
+
+        // Which keys select the deprecated shape. The manifest's own
+        // discriminator wins; SHAPE_DISCRIMINATORS covers the case where a Rust
+        // attribute merges sources that YAML keeps apart.
+        let when: Vec<String> = match item["discriminator"].as_object() {
+            Some(d) if d.get("present").and_then(Value::as_bool) == Some(true) => {
+                let field = d.get("field").and_then(Value::as_str).unwrap_or_default();
+                vec![rust_key(id, field)]
+            }
+            Some(_) => Vec::new(),
+            None => match SHAPE_DISCRIMINATORS.iter().find(|(d, _)| *d == id) {
+                Some((_, keys)) => keys.iter().map(|k| (*k).to_string()).collect(),
+                // Sole source: the whole attribute is deprecated.
+                None if sources.len() == 1 => Vec::new(),
+                None => {
+                    return Err(format!(
+                        "manifest deprecates `{id}`, which shares #[{attr}] with {} other manifest \
+                         item(s), but neither the manifest nor SHAPE_DISCRIMINATORS says which keys \
+                         select it. Warning unconditionally would fire on the current form too.",
+                        sources.len() - 1,
+                    ))
+                }
+            },
+        };
+
+        let replaced_id = dep["replacedBy"].as_str().unwrap_or_default();
+        let replaced_by = ATTR_SOURCES
+            .iter()
+            .find(|(_, s)| s.contains(&replaced_id))
+            .map(|(a, _)| *a)
+            .ok_or_else(|| {
+                format!(
+                    "manifest says `{id}` is replaced by `{replaced_id}`, which no Rust attribute \
+                     is authored from — the warning would name something the user cannot write."
+                )
+            })?;
+
+        // Reason, then the field mapping in Rust spelling. Identity entries
+        // (`selector` -> `selector`) carry nothing and are dropped.
+        let mut note = dep["reason"].as_str().unwrap_or_default().to_string();
+        let mapping: Vec<String> = dep["mapping"]
+            .as_object()
+            .map(|m| {
+                m.iter()
+                    .map(|(k, v)| {
+                        (
+                            camel_to_snake(k),
+                            camel_to_snake(v.as_str().unwrap_or_default()),
+                        )
+                    })
+                    .filter(|(k, v)| k != v)
+                    .map(|(k, v)| format!("{k} -> {v}"))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !mapping.is_empty() {
+            note.push_str(&format!(" Mapping: {}.", mapping.join("; ")));
+        }
+        if let Some(extra) = item["note"].as_str() {
+            note.push(' ');
+            note.push_str(extra);
+        }
+
+        let when_lits: Vec<String> = when.iter().map(|k| format!("{k:?}")).collect();
+        dep_entries.push(format!(
+            "    DeprecationSpec {{ attr: {:?}, when_any_key: &[{}], replaced_by: {:?}, note: {:?} }},",
+            attr,
+            when_lits.join(", "),
+            replaced_by,
+            note,
+        ));
+    }
+
+    // A stale exemption is as bad as a missing one: it means the policy table
+    // still excuses something the manifest no longer says.
+    for (id, _) in DEPRECATIONS_NOT_APPLICABLE {
+        if !deprecations.iter().any(|d| d["id"].as_str() == Some(*id)) {
+            return Err(format!(
+                "DEPRECATIONS_NOT_APPLICABLE in spec-codegen/src/lib.rs excuses `{id}`, which the \
+                 manifest no longer deprecates. Drop the entry."
+            ));
+        }
+    }
+
+    s.push_str(
+        "/// Forms spytial-core has deprecated, in the order the manifest lists them.\n\
+         pub static DEPRECATIONS: &[DeprecationSpec] = &[\n",
+    );
+    s.push_str(&dep_entries.join("\n"));
     s.push_str("\n];\n\n");
 
     // ---- orientation list rules ----

--- a/tests/decorators.rs
+++ b/tests/decorators.rs
@@ -231,6 +231,7 @@ fn edge_style_directive_all_options() {
 }
 
 #[derive(Serialize, SpytialDecorators)]
+#[allow(deprecated)]
 #[edge_style(
     field = "legacy_edge",
     value = "seagreen",
@@ -498,6 +499,7 @@ fn raw_selector_keeps_its_own_whitespace() {
 }
 
 #[derive(Serialize, SpytialDecorators)]
+#[allow(deprecated)]
 #[atom_color(selector = "Legacy", value = "crimson")]
 struct AtomColorLegacy {
     id: u32,
@@ -710,7 +712,9 @@ fn tag_directive_multiple() {
 #[align(selector = "Person", direction = "horizontal", negated = true)]
 #[cyclic(selector = "next", direction = "clockwise", negated = true)]
 #[group(selector = "Foo", name = "fooGroup", negated = true)]
-#[allow(clippy::duplicated_attributes)]
+// The field-based group is deprecated upstream, but `hold: never` has to keep
+// working on both group shapes, so this one stays.
+#[allow(clippy::duplicated_attributes, deprecated)]
 #[group(field = "rel", group_on = 0, add_to_group = 1, negated = true)]
 struct AllNegated {
     id: u32,
@@ -896,6 +900,7 @@ fn atom_style_carries_icon_style_and_show_label() {
 }
 
 #[derive(Serialize, SpytialDecorators)]
+#[allow(deprecated)]
 #[icon(selector = "Person", path = "person.png", show_labels = true)]
 struct LegacyIcon {
     name: String,
@@ -995,6 +1000,7 @@ fn cyclic_defaults_to_the_manifest_direction() {
 }
 
 #[derive(Serialize, SpytialDecorators)]
+#[allow(deprecated)]
 #[icon(selector = "Person", path = "person.png")]
 struct BareLegacyIcon {
     name: String,

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -333,13 +333,18 @@ fn recursive_struct_produces_multiple_typed_atoms() {
 // 9. Decorators are inherited through nested types
 // ──────────────────────────────────────────────
 
+// These two use the deprecated `atom_color` on purpose: what they check is that
+// a nested type's decorators reach the parent's spec, and the legacy form is the
+// shortest thing that produces one distinguishable directive per type.
 #[derive(Serialize, SpytialDecorators)]
+#[allow(deprecated)]
 #[atom_color(selector = "{x : Parent | true}", value = "blue")]
 struct Parent {
     child: Child,
 }
 
 #[derive(Serialize, SpytialDecorators)]
+#[allow(deprecated)]
 #[atom_color(selector = "{x : Child | true}", value = "red")]
 #[attribute(field = "name")]
 struct Child {
@@ -499,7 +504,11 @@ fn enum_derive_produces_empty_decorators() {
 // 14. Multiple constraint types compose
 // ──────────────────────────────────────────────
 
+// `atom_color` is deprecated but kept here deliberately: this test counts how
+// many constraints and directives a mixed set produces, and the legacy form is
+// one of the shapes that has to keep landing in the right section.
 #[derive(Serialize, SpytialDecorators)]
+#[allow(deprecated)]
 #[orientation(selector = "sel1", directions = ["left", "below"])]
 #[align(selector = "sel2", direction = "horizontal")]
 #[atom_color(selector = "sel3", value = "green")]


### PR DESCRIPTION
Follow-up to #82. That PR started generating the derive macro's spec tables
from spytial-core's language manifest, including a `deprecated_for` column —
which nothing ever read. This makes the deprecation data do something.

## What was wrong

**The data was extracted and dropped.** `AttrSpec::deprecated_for` was set
correctly for `atomColor` and `icon` and never looked at. `spec_tables.rs`
carries `#![allow(dead_code)]`, so it did not even warn about itself.

**`#[group(field = ...)]` had no signal at all.** Deprecation was recorded per
attribute, and `#[group]` is authored from two manifest items — `group` and the
deprecated `group.byField`. The codegen deliberately refuses to deprecate an
attribute on a merged source's behalf, which is right (`#[group]` is current),
and left the deprecated shape invisible.

## What this does

Warnings are keyed on the *form*, not the attribute:

| Written | Warns |
|---|---|
| `#[icon(...)]`, `#[atom_color(...)]` | yes — the attribute is deprecated |
| `#[group(field = ...)]` | yes |
| `#[group(selector = ...)]` | no — current form |
| `#[edge_style(value = ...)]` | yes |
| `#[edge_style(field = ..., line_style(...))]` | no — current form |
| `#[edge_style(field = "x")]` | no — see below |

A `DeprecationSpec` carries the keys whose presence selects the deprecated
shape, from the manifest's own `discriminator` where it has one. Empty means
the whole attribute is deprecated.

The bare `#[edge_style(field = "x")]` case stays quiet on purpose. It does take
the legacy path, but only because this crate defaults it to a blue line for
0.1 compatibility — the user wrote no deprecated key, so there is nothing to
tell them to change.

Nothing stops compiling and no behaviour changes. The deprecated forms are
still parsed and rewritten exactly as before.

## How it warns

Proc macros cannot raise warnings on stable, so the expansion emits a
`#[deprecated]` marker type and immediately uses it, with every token spanned
to the user's attribute:

```
warning: use of deprecated struct `_::group_field_form_is_deprecated`:
         `#[group(field = ...)]` is deprecated in spytial-core 4.3.0; use the
         current form of `#[group]`. A binary selector whose first column is
         the key and whose second is the members says the same thing without
         tuple indices. Mapping: add_to_group -> selector (column order);
         field -> selector; group_on -> selector (column order). To migrate:
         over `worksIn: Employee -> Department`, `groupOn: 1` / `addToGroup: 0`
         keys on Department, so it becomes `selector: ~worksIn` plus the `name`
         that form requires.
 --> examples/probe.rs:4:1
  |
4 | #[group(field = "worksIn", group_on = 1, add_to_group = 0)]
  | ^
```

The note text — reason, field mapping, migration — is generated from the
manifest's `deprecations[]`, with the mapping rendered in Rust spelling
(`iconStyle.path` becomes `icon_style.path`). It moves when upstream's does.

## Silencing it

`#[allow(deprecated)]` on the type works. It needed help: the marker is a
sibling item of the struct, so a plain `#[allow]` on the struct does **not**
reach it — I checked, and it does not. The expansion therefore copies the
type's `allow`/`expect` attributes onto the marker. Without that, quieting one
legacy attribute would take `#![allow(deprecated)]` over the whole module,
hiding every unrelated deprecation in it.

Escalation needs no help: a module- or crate-level `deny` already covers the
marker, since the module is its lint parent.

## Keeping it honest

- spec-codegen fails the build if spytial-core deprecates something that is
  neither warned about nor listed in `DEPRECATIONS_NOT_APPLICABLE` with a
  reason — and if a listed exemption goes stale. Exempt today: the two
  wire-section placements (not authoring forms) and the four inline
  `inferredEdge` fields (already in `FIELD_SKIPS`; the macro never took them).
- Six unit tests in the macro crate cover which forms warn, which stay quiet,
  that a legacy key name *inside* a style block is not a legacy key, and that
  every `when_any_key` names a key the attribute actually accepts — a typo
  there would produce a warning that can never fire.

## Also

**CI was not running the macro crate's unit tests.** `macros` is a path
dependency, not a workspace member, so `cargo test` at the root never reached
it and `--workspace` does not either. It now gets its own `--manifest-path`
step like `eval-corpus` and `spec-codegen`. (`cargo fmt --all` did already
reach it.)

The eight existing tests that exercise legacy forms on purpose got
`#[allow(deprecated)]` and were otherwise left alone — they are the coverage
proving the rewrites work.

Full matrix green, zero warnings: root tests, doc tests, macro unit tests,
spec-codegen drift, eval-corpus, `--all-targets` build, clippy, and rustfmt
across all three workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)