### PR TITLE
Make the derive's doc example compile, and run it

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,19 +33,17 @@ jobs:
       - name: Build all targets
         run: cargo build --all-targets
 
+      # `--workspace` covers the derive macro crate as well as `spytial`. It only
+      # does so because the root manifest now declares both as members; a path
+      # dependency alone is not a member, and these runs used to skip it.
       - name: Run unit and integration tests
-        run: cargo test --lib --tests
+        run: cargo test --workspace --lib --tests
 
+      # Guards the derive's own doc example, which never compiled and never ran.
       - name: Run doc tests
-        run: cargo test --doc
+        run: cargo test --workspace --doc
 
-      # `macros` is a path dependency, not a workspace member, so the runs above
-      # do not reach it and `--workspace` would not help. `--lib` only: its doc
-      # example needs `spytial`, which it cannot depend on without a cycle.
-      - name: Run derive-macro unit tests
-        run: cargo test --manifest-path macros/Cargo.toml --lib
-
-      # Its own workspace, so the run above does not reach it.
+      # Its own workspace, so the runs above do not reach it.
       - name: Run eval-corpus tests
         run: cargo test --manifest-path eval-corpus/Cargo.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Repo hygiene, no behaviour change:
+
+- The derive macro's doc example never compiled. It needs `spytial`, which
+  `spytial_export_macros` cannot depend on normally, and it went unnoticed
+  because nothing ever ran that crate's doc tests. It compiles and is tested
+  now, via a dev-dependency cycle — which Cargo permits, and which is stripped
+  from the published manifest, so the release order is unchanged.
+- `macros` is now a workspace member. A path dependency is not one on its own,
+  so `cargo test` and `cargo test --workspace` both skipped the derive macro
+  entirely; CI runs `--workspace` for tests and doc tests, and
+  `tests/workspace.rs` fails if the membership goes away again.
+- Nine clippy warnings in `macros` cleaned up (`unwrap_or_else(|| "".into())`
+  to `unwrap_or_default()`). They were never reported before, for the same
+  reason.
+- The attribute list in the derive's docs was checked against the generated
+  spec tables: every attribute and key matches, nothing is documented that the
+  macro does not accept.
+
 Deprecated forms now warn at compile time:
 
 - Every form spytial-core marks deprecated produces a `deprecated` warning

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,19 @@
+# Declaring a workspace at all is what pulls `macros` in: with no `[workspace]`
+# section the root package is a workspace of one, `cargo metadata` lists only
+# `spytial`, and `cargo test --workspace` silently skips the derive macro's own
+# tests. That is how a doc example which could never compile sat green in CI.
+#
+# Once the section exists, path dependencies under the workspace root are
+# members whether or not they are listed; `macros` is named anyway so the
+# intent survives a reader who does not know that rule. tests/workspace.rs
+# asserts the resolved membership, since deleting the section is the mistake
+# that costs coverage.
+#
+# `eval-corpus` and `spec-codegen` stay out on purpose — each declares its own
+# workspace, so they never enter this crate's build graph.
+[workspace]
+members = [".", "macros"]
+
 [package]
 name = "spytial"
 version = "0.3.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -20,3 +20,16 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+
+# The derive's doc example needs the crate the derive is *for*: the expansion
+# names `spytial::spytial_annotations::…`, so nothing here can compile it alone.
+# Cargo permits a dev-dependency cycle, and a path-only dev-dependency is
+# stripped when packaging, so `spytial` never appears in the published manifest
+# and the publish order (macros first, then spytial) is unchanged.
+#
+# Consequence worth knowing: the example is tested in this repo, not from a
+# downloaded .crate, where the stripped dev-dependency leaves it uncompilable
+# exactly as before. CI covers the case that matters.
+[dev-dependencies]
+spytial = { path = ".." }
+serde = { version = "1.0", features = ["derive"] }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1051,8 +1051,7 @@ fn parse_orientation_args(attr: &Attribute) -> Result<Option<SpatialAttribute>, 
         let tokens = &meta.tokens;
         let token_str = tokens.to_string();
 
-        let selector =
-            extract_string_from_tokens(&token_str, "selector").unwrap_or_else(|| "".to_string());
+        let selector = extract_string_from_tokens(&token_str, "selector").unwrap_or_default();
         // No default: `directions` is required, and the old fallback of
         // ["up", "down"] was outside the vocabulary entirely, so it produced a
         // constraint that matched nothing.
@@ -1097,8 +1096,7 @@ fn parse_group_args(attr: &Attribute) -> Result<Option<SpatialAttribute>, syn::E
             }))
         } else {
             // Selector-based grouping
-            let selector =
-                extract_string_from_tokens(&stripped, "selector").unwrap_or_else(|| "".to_string());
+            let selector = extract_string_from_tokens(&stripped, "selector").unwrap_or_default();
             let name = extract_string_from_tokens(&stripped, "name")
                 .unwrap_or_else(|| "default".to_string());
             let add_edge = parse_add_edge(attr, &token_str, &stripped)?;
@@ -1123,8 +1121,7 @@ fn parse_align_args(attr: &Attribute) -> Result<Option<SpatialAttribute>, syn::E
         let tokens = &meta.tokens;
         let token_str = tokens.to_string();
 
-        let selector =
-            extract_string_from_tokens(&token_str, "selector").unwrap_or_else(|| "".to_string());
+        let selector = extract_string_from_tokens(&token_str, "selector").unwrap_or_default();
         let direction = extract_string_from_tokens(&token_str, "direction")
             .unwrap_or_else(|| "horizontal".to_string());
         check_direction(attr, "align", &direction)?;
@@ -1146,8 +1143,7 @@ fn parse_cyclic_args(attr: &Attribute) -> Result<Option<SpatialAttribute>, syn::
         let tokens = &meta.tokens;
         let token_str = tokens.to_string();
 
-        let selector =
-            extract_string_from_tokens(&token_str, "selector").unwrap_or_else(|| "".to_string());
+        let selector = extract_string_from_tokens(&token_str, "selector").unwrap_or_default();
         // The manifest's own default. The old fallback here was "up", which is
         // not a cycle direction at all — spytial-core would accept it and lay
         // out clockwise regardless.
@@ -1172,8 +1168,7 @@ fn parse_atom_color_args(attr: &Attribute) -> Result<Option<SpatialAttribute>, s
         let tokens = &meta.tokens;
         let token_str = tokens.to_string();
 
-        let selector =
-            extract_string_from_tokens(&token_str, "selector").unwrap_or_else(|| "".to_string());
+        let selector = extract_string_from_tokens(&token_str, "selector").unwrap_or_default();
         let value =
             extract_string_from_tokens(&token_str, "value").unwrap_or_else(|| "blue".to_string());
 
@@ -1189,8 +1184,7 @@ fn parse_size_args(attr: &Attribute) -> Result<Option<SpatialAttribute>, syn::Er
         let tokens = &meta.tokens;
         let token_str = tokens.to_string();
 
-        let selector =
-            extract_string_from_tokens(&token_str, "selector").unwrap_or_else(|| "".to_string());
+        let selector = extract_string_from_tokens(&token_str, "selector").unwrap_or_default();
         let height = extract_number_from_tokens(&token_str, "height").unwrap_or(20);
         let width = extract_number_from_tokens(&token_str, "width").unwrap_or(30);
         // Both are `exclusiveMinimum: 0` upstream; a zero-sized atom is a
@@ -1214,8 +1208,7 @@ fn parse_icon_args(attr: &Attribute) -> Result<Option<SpatialAttribute>, syn::Er
         let tokens = &meta.tokens;
         let token_str = tokens.to_string();
 
-        let selector =
-            extract_string_from_tokens(&token_str, "selector").unwrap_or_else(|| "".to_string());
+        let selector = extract_string_from_tokens(&token_str, "selector").unwrap_or_default();
         let path = extract_string_from_tokens(&token_str, "path")
             .unwrap_or_else(|| "icon.png".to_string());
         // The manifest's default is `false`, not `true`. Getting this backwards
@@ -1369,8 +1362,7 @@ fn parse_hide_atom_args(attr: &Attribute) -> Result<Option<SpatialAttribute>, sy
         let tokens = &meta.tokens;
         let token_str = tokens.to_string();
 
-        let selector =
-            extract_string_from_tokens(&token_str, "selector").unwrap_or_else(|| "".to_string());
+        let selector = extract_string_from_tokens(&token_str, "selector").unwrap_or_default();
 
         Ok(Some(SpatialAttribute::HideAtom { selector }))
     } else {
@@ -1387,8 +1379,7 @@ fn parse_inferred_edge_args(attr: &Attribute) -> Result<Option<SpatialAttribute>
 
         let name =
             extract_string_from_tokens(&stripped, "name").unwrap_or_else(|| "edge".to_string());
-        let selector =
-            extract_string_from_tokens(&stripped, "selector").unwrap_or_else(|| "".to_string());
+        let selector = extract_string_from_tokens(&stripped, "selector").unwrap_or_default();
 
         Ok(Some(SpatialAttribute::InferredEdge {
             name,

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,0 +1,53 @@
+//! Guards the build configuration that decides what actually gets tested.
+//!
+//! This lives in the root crate on purpose. A test inside `macros/` could not
+//! do the job: if that crate stops being a workspace member, `cargo test
+//! --workspace` skips it, so a guard placed there would never run and never
+//! fail — the same silence it is meant to catch.
+
+use std::process::Command;
+
+/// `macros` has to resolve as a workspace member, not merely as a path
+/// dependency.
+///
+/// A package with no `[workspace]` section is a workspace of one: `cargo
+/// metadata` reports only `spytial`, and both `cargo test` and `cargo test
+/// --workspace` skip the derive macro entirely — its unit tests and its doc
+/// example included. That is how a doc example which could never compile sat
+/// green in CI: nothing ever ran it.
+///
+/// Asked of `cargo metadata` rather than of the manifest text, because the
+/// resolved workspace is what decides which crates run. Reading the manifest
+/// would also get the rule wrong in both directions: once the section exists
+/// path dependencies join whether listed or not, and a comment mentioning
+/// `[workspace]` is enough to fool a parser.
+#[test]
+fn the_derive_macro_crate_is_a_workspace_member() {
+    let out = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("cargo metadata runs");
+    assert!(
+        out.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let meta: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("cargo metadata emits JSON");
+    let members: Vec<&str> = meta["packages"]
+        .as_array()
+        .expect("metadata has packages")
+        .iter()
+        .filter_map(|p| p["name"].as_str())
+        .collect();
+
+    assert!(
+        members.contains(&"spytial_export_macros"),
+        "`spytial_export_macros` is not a workspace member — the workspace is {members:?}.\n\
+         A path dependency is not a member: without it listed, `cargo test --workspace` \
+         silently stops running the derive macro's unit tests and its doc example, \
+         with no failure to notice.",
+    );
+}


### PR DESCRIPTION
Stacked on #83 — it touches the same two files, so this targets that branch
rather than `main`. Retarget once #83 lands.

## The bug

The `# Example` on `derive_spytial_decorators` could never have compiled. It
does `use spytial::SpytialDecorators;`, and the expansion names
`spytial::spytial_annotations::…`, so nothing inside the macro crate can build
it:

```
cargo test --manifest-path macros/Cargo.toml --doc
error[E0432]: unresolved import `spytial`
error: cannot find attribute `attribute` in this scope
```

It stayed green because nothing ever ran that crate's doc tests.

## The fix

The obvious move is ```` ```ignore ````, which keeps the example rendering while
admitting it is decorative. Instead the macro crate takes a dev-dependency on
`spytial`, so the example is genuinely compiled and tested.

Cargo permits a dev-dependency cycle, and a **path-only dev-dependency is
stripped when packaging**. I unpacked the `.crate` to confirm — the published
manifest carries `[dev-dependencies.serde]` and no `spytial` entry, so
`cargo package` succeeds and the publish order (macros, then spytial) is
unchanged.

Worth knowing: the example is tested *in this repo*. From a downloaded
`.crate` the stripped dev-dependency leaves it as uncompilable as it is today
— that is the case nobody runs, and it is no worse than the status quo.

## Running it required fixing the workspace

`macros` was a path dependency and nothing more. A package with **no
`[workspace]` section is a workspace of one**, so `cargo metadata` reported
only `spytial` and `cargo test` skipped the derive macro — `--workspace`
included. That is why the task this came from asked for
`cargo test --workspace --doc`: as written it would have passed without testing
anything.

Declaring the workspace is what pulls `macros` in. Note the actual rule, which
I got wrong at first: once the section exists, path dependencies under the
workspace root are members **whether or not they are listed**. Removing
`"macros"` from `members` changes nothing; deleting the section is what breaks
it.

| Root manifest | `cargo metadata --no-deps` |
|---|---|
| no `[workspace]` (before) | `["spytial"]` |
| `members = ["."]` | `["spytial", "spytial_export_macros"]` |
| `members = [".", "macros"]` | `["spytial", "spytial_export_macros"]` |

CI now runs `--workspace` for tests and doc tests, replacing the
`--manifest-path macros/…` step added in #83.

## Guard

`tests/workspace.rs` asserts the resolved membership — losing it costs coverage
silently, which is the entire bug. Two deliberate choices:

- **In the root crate**, not in `macros`. A guard inside `macros` would stop
  running in exactly the case it exists to catch.
- **Asks `cargo metadata`**, not the manifest text. The text says less than it
  appears to (see the table), and my first attempt was fooled by a comment in
  `Cargo.toml` that contains the string `[workspace]`.

Verified it fails on the real regression:

```
`spytial_export_macros` is not a workspace member — the workspace is ["spytial"].
```

## Also from the same blind spot

Nine clippy warnings in `macros`, all `unwrap_or_else(|| "".to_string())` →
`unwrap_or_default()`. Never reported because clippy never looked there. CI
does not run clippy, so these were not failing anything — but the repo was at
zero warnings and making the crate visible is what surfaced them.

## Doc audit

The task also asked me to check the hand-maintained attribute list in the
derive's docs against the generated `spec_tables.rs`. It is accurate: every
attribute appears in both, every generated key is mentioned in the prose, and
nothing is documented that the macro would reject. No changes needed.

`cargo package` on the root crate fails both before and after this change
(`spytial_export_macros 0.3.0` is not on crates.io yet) — pre-existing, not
introduced here.

Green: workspace tests, workspace doc tests, spec-codegen drift, eval-corpus,
`--all-targets` build, clippy, rustfmt across all three workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)