### PR TITLE
Join relation headers position-wise instead of freezing them on the first tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed: a relation's type signature is no longer frozen by whichever tuple
+  arrived first (#79). Relations are keyed by name in one flat namespace, so
+  two structs with a same-named field share one relation; its header `types`
+  is now the position-wise join of every tuple's types — positions all tuples
+  agree on keep their concrete type, positions that vary widen to `"atom"`.
+  The join is order-independent. When a user field shares its name with a
+  built-in relation of different arity (a field literally named `idx` or
+  `map_entry`), the header joins the common prefix and keeps the longest
+  arity seen; per-tuple `ITuple.types` remains exact in all cases, and
+  round-trips through `reify` are unaffected. Also corrected the `IRelation`
+  docs, which showed a concrete target type (`name(Person, string)`) that the
+  exporter never emits — the target position is always the literal `"atom"`.
+
 The derive macro's accepted keys and compile-time validation are now generated
 from spytial-core's own language manifest instead of transcribed by hand:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ Repo hygiene, no behaviour change:
 - Nine clippy warnings in `macros` cleaned up (`unwrap_or_else(|| "".into())`
   to `unwrap_or_default()`). They were never reported before, for the same
   reason.
+- The workspace now excludes `.claude/worktrees`, where Claude Code nests its
+  git worktrees inside the checkout. A worktree on a branch predating the
+  `[workspace]` section has none of its own, so cargo walked up, hit this
+  checkout's manifest, and refused to build the worktree ("current package
+  believes it's in a workspace when it's not"). This also required dropping
+  `.` from `members`: exclusion is "under an excluded path and not under a
+  member path", both prefix checks, so a literal `.` made every path in the
+  checkout a member prefix and silently defeated `exclude`. The root package
+  is a member regardless — it hosts the `[workspace]` section — and
+  `tests/workspace.rs` now guards the exclusion with a throwaway nested
+  package, alongside the membership guard.
 - The attribute list in the derive's docs was checked against the generated
   spec tables: every attribute and key matches, nothing is documented that the
   macro does not accept.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The join is order-independent. When a user field shares its name with a
   built-in relation of different arity (a field literally named `idx` or
   `map_entry`), the header joins the common prefix and keeps the longest
-  arity seen; per-tuple `ITuple.types` remains exact in all cases, and
-  round-trips through `reify` are unaffected. Also corrected the `IRelation`
+  arity seen, and the relation's tuples are ordered longest-first — vendored
+  spytial-core's normalizer keeps a header only when its length matches the
+  first tuple's arity, so without the ordering the joined header would not
+  survive `JSONDataInstance` construction. Per-tuple `ITuple.types` remains
+  exact in all cases, and round-trips through `reify` are unaffected. Also
+  corrected the `IRelation`
   docs, which showed a concrete target type (`name(Person, string)`) that the
   exporter never emits — the target position is always the literal `"atom"`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,22 @@
 #
 # `eval-corpus` and `spec-codegen` stay out on purpose — each declares its own
 # workspace, so they never enter this crate's build graph.
+#
+# `.claude/worktrees` holds Claude Code's git worktrees, physically nested
+# inside this checkout. A worktree on a branch that predates this section has
+# no `[workspace]` of its own, so cargo walks up, lands on this file, and —
+# unless the path is excluded — refuses to build the worktree at all ("current
+# package believes it's in a workspace when it's not"). tests/workspace.rs
+# asserts the exclusion holds, the same way it guards the membership.
+#
+# `.` must not appear in `members` for that exclusion to work: cargo decides
+# exclusion as "under an excluded path and not under a member path", and both
+# are prefix checks, so a literal `.` makes every path in the checkout count
+# as a member prefix and silently defeats `exclude`. The root package is a
+# member regardless — it hosts this `[workspace]` section.
 [workspace]
-members = [".", "macros"]
+members = ["macros"]
+exclude = [".claude/worktrees"]
 
 [package]
 name = "spytial"

--- a/src/export.rs
+++ b/src/export.rs
@@ -26,8 +26,33 @@ use serde::ser::{
     Serialize, SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
     SerializeTupleStruct, SerializeTupleVariant, Serializer,
 };
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt;
+
+/// Join an incoming tuple's position types into a relation's stored header.
+///
+/// Relations are keyed by name in one flat namespace, so tuples from different
+/// source types can land in the same relation (two structs with a same-named
+/// field, or a field that shares its name with a built-in like `idx`). The
+/// header must describe all of them: positions on which every tuple agrees
+/// keep their concrete type, positions that vary widen to `"atom"`, the
+/// universal position type. When arities differ the common prefix is joined
+/// and the header keeps the longest arity seen, so every position that occurs
+/// in any tuple is described.
+///
+/// The join is commutative and associative, so the header is independent of
+/// the order in which tuples arrive.
+fn join_position_types(header: &mut Vec<String>, incoming: &[String]) {
+    for (have, new) in header.iter_mut().zip(incoming) {
+        if have != new {
+            *have = "atom".to_string();
+        }
+    }
+    if incoming.len() > header.len() {
+        header.extend_from_slice(&incoming[header.len()..]);
+    }
+}
 
 /// Export a Rust data structure to our JSON instance format using custom Serde serialization.
 ///
@@ -162,13 +187,21 @@ impl JsonDataSerializer {
             types: types.clone(),
         };
 
-        let rel = self.relations.entry(name.to_string()).or_insert(IRelation {
-            id: name.to_string(),
-            name: name.to_string(),
-            types,
-            tuples: vec![],
-        });
-        rel.tuples.push(tuple);
+        match self.relations.entry(name.to_string()) {
+            Entry::Vacant(entry) => {
+                entry.insert(IRelation {
+                    id: name.to_string(),
+                    name: name.to_string(),
+                    types,
+                    tuples: vec![tuple],
+                });
+            }
+            Entry::Occupied(mut entry) => {
+                let rel = entry.get_mut();
+                join_position_types(&mut rel.types, &tuple.types);
+                rel.tuples.push(tuple);
+            }
+        }
     }
 
     /// Merge decorators for `type_name` into the collected set, if it has any

--- a/src/export.rs
+++ b/src/export.rs
@@ -54,6 +54,25 @@ fn join_position_types(header: &mut Vec<String>, incoming: &[String]) {
     }
 }
 
+/// Turn the serializer's relation map into the wire-format list.
+///
+/// Tuples are ordered longest-arity-first (stably, so serialization order is
+/// kept within an arity, and uniform-arity relations are untouched). This is
+/// for spytial-core's benefit: `DataInstanceNormalizer.inferRelationSignatures`
+/// runs unconditionally on `JSONDataInstance` construction and keeps a
+/// relation's header only when its length equals the *first* tuple's arity,
+/// re-inferring it at that arity otherwise. The joined header has the longest
+/// arity that occurs, so a longest tuple must come first for the header to
+/// survive — and for the consumed signature to stay independent of
+/// serialization order in the mixed-arity collision case.
+fn finalize_relations(relations: HashMap<String, IRelation>) -> Vec<IRelation> {
+    let mut relations: Vec<IRelation> = relations.into_values().collect();
+    for rel in &mut relations {
+        rel.tuples.sort_by_key(|t| std::cmp::Reverse(t.atoms.len()));
+    }
+    relations
+}
+
 /// Export a Rust data structure to our JSON instance format using custom Serde serialization.
 ///
 /// Returns an empty [`JsonDataInstance`] if the value's `Serialize` impl fails. Use
@@ -80,7 +99,7 @@ pub fn try_export_json_instance<T: Serialize>(
     value.serialize(&mut serializer)?;
     Ok(JsonDataInstance {
         atoms: serializer.atoms,
-        relations: serializer.relations.into_values().collect(),
+        relations: finalize_relations(serializer.relations),
     })
 }
 
@@ -117,7 +136,7 @@ pub fn try_export_json_instance_with_decorators<T: Serialize>(
     value.serialize(&mut serializer)?;
     let instance = JsonDataInstance {
         atoms: serializer.atoms,
-        relations: serializer.relations.into_values().collect(),
+        relations: finalize_relations(serializer.relations),
     };
     Ok((instance, serializer.collected_decorators))
 }

--- a/src/jsondata.rs
+++ b/src/jsondata.rs
@@ -79,7 +79,9 @@ pub struct ITuple {
 /// shares its name with a built-in relation of different arity (a field
 /// literally named `idx` or `map_entry`): its tuples land in the built-in's
 /// relation, mixing arities. Per-tuple [`ITuple::types`] stays exact either
-/// way.
+/// way, and tuples are ordered longest-arity-first so that [`Self::types`]
+/// always has the first tuple's arity — spytial-core's normalizer discards
+/// any header whose length differs from it.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IRelation {
     /// Stable identifier for the relation (currently the same as [`Self::name`]).

--- a/src/jsondata.rs
+++ b/src/jsondata.rs
@@ -67,18 +67,29 @@ pub struct ITuple {
     pub types: Vec<String>,
 }
 
-/// A relation — a named, typed edge set. All tuples in a relation share
-/// the same arity and position types.
+/// A relation — a named, typed edge set. Relations are keyed by name in a
+/// single flat namespace, so same-named edges from different source types
+/// (two structs that each have a `name` field, say) share one relation.
 ///
-/// Examples: a field relation `name(Person, string)`, a sequence relation
-/// `idx(sequence, index, T)`, or a map relation `map_entry(map, K, V)`.
+/// Examples: a field relation `name(Person, atom)`, a sequence relation
+/// `idx(sequence, index, atom)`, or a map relation `map_entry(map, atom, atom)`.
+/// The target position is always the literal `"atom"`, the universal type.
+///
+/// Tuples normally share one arity. The exception is a struct field that
+/// shares its name with a built-in relation of different arity (a field
+/// literally named `idx` or `map_entry`): its tuples land in the built-in's
+/// relation, mixing arities. Per-tuple [`ITuple::types`] stays exact either
+/// way.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IRelation {
     /// Stable identifier for the relation (currently the same as [`Self::name`]).
     pub id: String,
     /// Relation name — `"idx"`, `"map_entry"`, or a struct field name.
     pub name: String,
-    /// Type names for each position in the tuples, in position order.
+    /// Position types for the relation as a whole: the position-wise join of
+    /// every tuple's [`ITuple::types`]. A position on which all tuples agree
+    /// keeps its concrete type; one that varies is widened to `"atom"`. If
+    /// tuple arities differ, the header has the longest arity that occurs.
     pub types: Vec<String>,
     /// All tuples belonging to this relation.
     pub tuples: Vec<ITuple>,

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -825,6 +825,12 @@ struct MixedArity {
     b: Vec<u32>,
 }
 
+#[derive(Serialize)]
+struct MixedArityReversed {
+    b: Vec<u32>,
+    a: HasIdx,
+}
+
 #[test]
 fn field_colliding_with_different_arity_builtin_keeps_longest_header() {
     let inst = export_json_instance(&MixedArity {
@@ -844,4 +850,38 @@ fn field_colliding_with_different_arity_builtin_keeps_longest_header() {
     for tuple in seq_tuples {
         assert_eq!(tuple.types, vec!["sequence", "index", "atom"]);
     }
+}
+
+#[test]
+fn mixed_arity_relation_orders_longest_tuples_first() {
+    // spytial-core's `DataInstanceNormalizer.inferRelationSignatures` runs on
+    // every `JSONDataInstance` construction and keeps a relation header only
+    // when its length equals the *first* tuple's arity — otherwise it re-infers
+    // a signature at that arity. The joined header has the longest arity that
+    // occurs, so a longest tuple must come first, regardless of which side of
+    // the collision serialized first.
+    let forward = export_json_instance(&MixedArity {
+        a: HasIdx { idx: 9 },
+        b: vec![10, 11],
+    });
+    let reversed = export_json_instance(&MixedArityReversed {
+        b: vec![10, 11],
+        a: HasIdx { idx: 9 },
+    });
+
+    for inst in [&forward, &reversed] {
+        for rel in &inst.relations {
+            assert_eq!(
+                rel.types.len(),
+                rel.tuples[0].types.len(),
+                "relation {:?}: header arity must match the first tuple's, \
+                 or spytial-core's normalizer replaces the header",
+                rel.name
+            );
+        }
+    }
+    assert_eq!(
+        relation(&forward, "idx").types,
+        relation(&reversed, "idx").types
+    );
 }

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -689,3 +689,150 @@ fn data_instance_and_decorators_agree_on_types() {
     assert!(yaml.contains("Parent"), "decorator yaml references Parent");
     assert!(yaml.contains("Child"), "decorator yaml references Child");
 }
+
+// ──────────────────────────────────────────────
+// 19. Same-named relations across types join their header (issue #79)
+// ──────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct Person {
+    name: String,
+}
+
+#[derive(Serialize)]
+struct Company {
+    name: String,
+}
+
+#[derive(Serialize)]
+struct BothNames {
+    p: Person,
+    c: Company,
+}
+
+#[derive(Serialize)]
+struct BothNamesReversed {
+    c: Company,
+    p: Person,
+}
+
+#[test]
+fn same_named_field_across_types_widens_relation_header() {
+    let inst = export_json_instance(&BothNames {
+        p: Person { name: "Ada".into() },
+        c: Company {
+            name: "Acme".into(),
+        },
+    });
+
+    let rel = relation(&inst, "name");
+    assert_eq!(rel.tuples.len(), 2);
+
+    // The header describes both source types only by widening to "atom".
+    assert_eq!(rel.types, vec!["atom", "atom"]);
+
+    // Per-tuple types stay exact.
+    let person_id = &atom_by_type(&inst, "Person").id;
+    let company_id = &atom_by_type(&inst, "Company").id;
+    for tuple in &rel.tuples {
+        let expected = if &tuple.atoms[0] == person_id {
+            vec!["Person", "atom"]
+        } else {
+            assert_eq!(&tuple.atoms[0], company_id);
+            vec!["Company", "atom"]
+        };
+        assert_eq!(tuple.types, expected);
+    }
+}
+
+#[test]
+fn joined_header_is_independent_of_tuple_order() {
+    let forward = export_json_instance(&BothNames {
+        p: Person { name: "Ada".into() },
+        c: Company {
+            name: "Acme".into(),
+        },
+    });
+    let reversed = export_json_instance(&BothNamesReversed {
+        c: Company {
+            name: "Acme".into(),
+        },
+        p: Person { name: "Ada".into() },
+    });
+
+    assert_eq!(
+        relation(&forward, "name").types,
+        relation(&reversed, "name").types
+    );
+}
+
+#[test]
+fn single_source_type_keeps_precise_header() {
+    let inst = export_json_instance(&Flat {
+        name: "solo".into(),
+        age: 1,
+    });
+
+    assert_eq!(relation(&inst, "name").types, vec!["Flat", "atom"]);
+    assert_eq!(relation(&inst, "age").types, vec!["Flat", "atom"]);
+}
+
+// A user field named like the built-in `value` relation (same arity):
+// the shared header widens, nothing else changes.
+
+#[derive(Serialize)]
+struct Meters(f64);
+
+#[derive(Serialize)]
+struct ValueCollision {
+    a: Inner,  // field relation value(Inner, atom)
+    b: Meters, // newtype relation value(newtype_struct, atom)
+}
+
+#[test]
+fn field_colliding_with_builtin_value_relation_widens_header() {
+    let inst = export_json_instance(&ValueCollision {
+        a: Inner { value: 7 },
+        b: Meters(1.5),
+    });
+
+    let rel = relation(&inst, "value");
+    assert_eq!(rel.tuples.len(), 2);
+    assert_eq!(rel.types, vec!["atom", "atom"]);
+}
+
+// A user field named like the built-in `idx` relation (different arity):
+// the header joins the common prefix and keeps the longest arity, and
+// per-tuple types/arity remain exact for every tuple.
+
+#[derive(Serialize)]
+struct HasIdx {
+    idx: u32,
+}
+
+#[derive(Serialize)]
+struct MixedArity {
+    a: HasIdx,
+    b: Vec<u32>,
+}
+
+#[test]
+fn field_colliding_with_different_arity_builtin_keeps_longest_header() {
+    let inst = export_json_instance(&MixedArity {
+        a: HasIdx { idx: 9 },
+        b: vec![10, 11],
+    });
+
+    let rel = relation(&inst, "idx");
+    assert_eq!(rel.tuples.len(), 3);
+    assert_eq!(rel.types, vec!["atom", "atom", "atom"]);
+
+    let field_tuples: Vec<_> = rel.tuples.iter().filter(|t| t.atoms.len() == 2).collect();
+    let seq_tuples: Vec<_> = rel.tuples.iter().filter(|t| t.atoms.len() == 3).collect();
+    assert_eq!(field_tuples.len(), 1);
+    assert_eq!(seq_tuples.len(), 2);
+    assert_eq!(field_tuples[0].types, vec!["HasIdx", "atom"]);
+    for tuple in seq_tuples {
+        assert_eq!(tuple.types, vec!["sequence", "index", "atom"]);
+    }
+}

--- a/tests/reify.rs
+++ b/tests/reify.rs
@@ -208,3 +208,62 @@ fn nested_options_round_trip() {
     full_roundtrip(Some(Some(Option::<i32>::None))); // Some(Some(None))
     full_roundtrip(vec![Some(Some(1_i32)), Some(None), None]);
 }
+
+#[test]
+fn colliding_relation_names_round_trip() {
+    // Relations are keyed by name in one flat namespace, so same-named edges
+    // from different types share a relation whose header is widened position-
+    // wise (issue #79). Reify buckets tuples by source atom, so round-trips
+    // must be unaffected — even for a field named like a built-in relation of
+    // different arity (`idx`), which produces a mixed-arity relation.
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Person {
+        name: String,
+    }
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Company {
+        name: String,
+    }
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct BothNames {
+        p: Person,
+        c: Company,
+    }
+    full_roundtrip(BothNames {
+        p: Person { name: "Ada".into() },
+        c: Company {
+            name: "Acme".into(),
+        },
+    });
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct HasIdx {
+        idx: u32,
+    }
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct MixedArity {
+        a: HasIdx,
+        b: Vec<u32>,
+    }
+    full_roundtrip(MixedArity {
+        a: HasIdx { idx: 9 },
+        b: vec![10, 11],
+    });
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Meters(f64);
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct HasValue {
+        value: u32,
+    }
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct ValueCollision {
+        a: HasValue,
+        b: Meters,
+    }
+    full_roundtrip(ValueCollision {
+        a: HasValue { value: 7 },
+        b: Meters(1.5),
+    });
+}

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -51,3 +51,51 @@ fn the_derive_macro_crate_is_a_workspace_member() {
          with no failure to notice.",
     );
 }
+
+/// A package nested under `.claude/worktrees/` has to resolve standalone.
+///
+/// Claude Code parks git worktrees there, physically inside this checkout. A
+/// worktree on a branch that predates the `[workspace]` section has none of
+/// its own, so cargo walks up from the nested package, lands on this crate's
+/// manifest, and — if the path is neither member nor excluded — refuses to
+/// build the worktree at all: "current package believes it's in a workspace
+/// when it's not". The `exclude` entry is what keeps such worktrees buildable.
+///
+/// Exercised with a throwaway package rather than by reading the manifest,
+/// for the same reason as above: exclusion is resolution behavior (it covers
+/// everything beneath the excluded directory), and only cargo can say whether
+/// it applies.
+#[test]
+fn packages_under_claude_worktrees_resolve_standalone() {
+    let probe = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(".claude/worktrees")
+        .join(format!("exclusion-probe-{}", std::process::id()));
+
+    struct RemoveOnDrop(std::path::PathBuf);
+    impl Drop for RemoveOnDrop {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    std::fs::create_dir_all(probe.join("src")).expect("create probe package dir");
+    let _cleanup = RemoveOnDrop(probe.clone());
+    std::fs::write(
+        probe.join("Cargo.toml"),
+        "[package]\nname = \"exclusion-probe\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write probe manifest");
+    std::fs::write(probe.join("src/lib.rs"), "").expect("write probe lib.rs");
+
+    let out = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(&probe)
+        .output()
+        .expect("cargo metadata runs");
+    assert!(
+        out.status.success(),
+        "a package under .claude/worktrees/ no longer resolves standalone — \
+         is `.claude/worktrees` missing from this workspace's `exclude`?\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}


### PR DESCRIPTION
Fixes #79. Also includes the workspace fix that was briefly PR #86, now consolidated here (this branch merges current `main`).

# Relation headers: join position-wise instead of freezing on the first tuple

`push_relation` `or_insert`-ed a relation's header `types` from whichever tuple arrived first and never revised it, so a `name` relation containing both `Person.name` and `Company.name` tuples claimed `(Person, atom)` for everything. The header is now the **position-wise join** of every tuple's types:

- positions all tuples agree on keep their concrete type
- positions that vary widen to `"atom"`, the universal position type

The join is commutative and associative, so the header is independent of serialization order (pinned by a test that exports the same data with field order flipped). This is the fix the issue proposed: widen the shared header, don't split the namespace — `IRelation.id`/`name` are untouched, so decorator selectors and downstream consumers see the same relation names as before.

## The arity open question

The issue left mixed arity open: a user field literally named `idx` or `map_entry` (arity 2) lands in the built-in relation (arity 3). No header can make that relation honest under the "all tuples share one arity" contract without renaming something, and renaming was the option already rejected. The join is instead made **total**: the common prefix is joined position-wise and the header keeps the longest arity seen, so every position that occurs in any tuple is described and the result is still order-independent. For the issue's repro that yields `["atom", "atom", "atom"]`. Per Codex's review: the vendored core's `DataInstanceNormalizer.inferRelationSignatures` runs unconditionally on `JSONDataInstance` construction and keeps a header only when its length equals the *first* tuple's arity, so tuples are additionally ordered longest-arity-first (stable sort — uniform-arity relations untouched); verified by feeding real exported instances for both field orders through the vendored bundle's constructor in node, which yields `idx["atom","atom","atom"]` either way. Per-tuple `ITuple.types` stays exact in all cases, and the `IRelation` docs now state the mixed-arity caveat instead of a contract the exporter can't keep.

Whether built-in relation names should be *reserved* (escaping colliding user fields into their own relations) is deliberately left as a possible follow-up — it changes wire names that selectors key on, the same concern that ruled out namespacing.

## Also

- Fixed the `IRelation` doc examples: `name(Person, string)` → `name(Person, atom)`; the target position is always the literal `"atom"`, no relation ever carries a concrete target type.

## Tests

- `same_named_field_across_types_widens_relation_header` — the issue's repro; header widens, per-tuple types stay exact
- `joined_header_is_independent_of_tuple_order` — same data, flipped field order, identical header
- `single_source_type_keeps_precise_header` — no collision → no widening regression
- `field_colliding_with_builtin_value_relation_widens_header` — equal-arity built-in collision (`value`)
- `field_colliding_with_different_arity_builtin_keeps_longest_header` — the mixed-arity `idx` case
- `colliding_relation_names_round_trip` (reify) — all three collision shapes round-trip exactly, confirming the issue's claim that reify buckets by source atom and is unaffected

# Workspace: exclude `.claude/worktrees` so nested worktrees build standalone

Claude Code parks its git worktrees under `.claude/worktrees/`, physically inside the checkout. A worktree on a branch that predates #84's `[workspace]` section has no workspace of its own, so cargo walks up from the nested package, lands on the checkout's manifest, and refuses to build the worktree entirely:

```
error: current package believes it's in a workspace when it's not
```

Observed 2026-08-02 in this PR's own worktree while the main checkout carried the `[workspace]` table.

Two changes, one of them a footgun:

- `exclude = [".claude/worktrees"]` in the `[workspace]` table.
- **`.` dropped from `members`.** This one is load-bearing and non-obvious: cargo decides exclusion as "under an excluded path *and not under a member path*", and both are prefix checks, so the literal `.` made every path in the checkout count as a member prefix and silently defeated `exclude`. (The guard test caught this.) The root package remains a workspace member regardless, by virtue of hosting the `[workspace]` section; the existing membership guard in `tests/workspace.rs` still passes, so #84's coverage fix is intact.

Following `tests/workspace.rs`'s assert-resolved-behavior philosophy, the exclusion gets the same guard treatment as the membership: a test materializes a throwaway package under `.claude/worktrees/`, runs `cargo metadata` in it, and asserts it resolves standalone. One caveat for local runs: the probe walks *all* ancestor manifests, so inside a nested worktree it only passes once the outer checkout's branch also carries the exclusion — on CI's flat checkout it passes as of this branch.

## Verification

All suites green with `cargo test` and `cargo test --workspace` (including the macros crate and both workspace guards), plus the eval corpus. `cargo test` run from inside this pre-`[workspace]` worktree with the exclusion in the outer checkout: previously the hard error above, now fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
