### PR TITLE
Exclude .claude/worktrees from the workspace so nested worktrees build standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ Repo hygiene, no behaviour change:
 - Nine clippy warnings in `macros` cleaned up (`unwrap_or_else(|| "".into())`
   to `unwrap_or_default()`). They were never reported before, for the same
   reason.
+- The workspace now excludes `.claude/worktrees`, where Claude Code nests its
+  git worktrees inside the checkout. A worktree on a branch predating the
+  `[workspace]` section has none of its own, so cargo walked up, hit this
+  checkout's manifest, and refused to build the worktree ("current package
+  believes it's in a workspace when it's not"). This also required dropping
+  `.` from `members`: exclusion is "under an excluded path and not under a
+  member path", both prefix checks, so a literal `.` made every path in the
+  checkout a member prefix and silently defeated `exclude`. The root package
+  is a member regardless — it hosts the `[workspace]` section — and
+  `tests/workspace.rs` now guards the exclusion with a throwaway nested
+  package, alongside the membership guard.
 - The attribute list in the derive's docs was checked against the generated
   spec tables: every attribute and key matches, nothing is documented that the
   macro does not accept.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,22 @@
 #
 # `eval-corpus` and `spec-codegen` stay out on purpose — each declares its own
 # workspace, so they never enter this crate's build graph.
+#
+# `.claude/worktrees` holds Claude Code's git worktrees, physically nested
+# inside this checkout. A worktree on a branch that predates this section has
+# no `[workspace]` of its own, so cargo walks up, lands on this file, and —
+# unless the path is excluded — refuses to build the worktree at all ("current
+# package believes it's in a workspace when it's not"). tests/workspace.rs
+# asserts the exclusion holds, the same way it guards the membership.
+#
+# `.` must not appear in `members` for that exclusion to work: cargo decides
+# exclusion as "under an excluded path and not under a member path", and both
+# are prefix checks, so a literal `.` makes every path in the checkout count
+# as a member prefix and silently defeats `exclude`. The root package is a
+# member regardless — it hosts this `[workspace]` section.
 [workspace]
-members = [".", "macros"]
+members = ["macros"]
+exclude = [".claude/worktrees"]
 
 [package]
 name = "spytial"

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -51,3 +51,51 @@ fn the_derive_macro_crate_is_a_workspace_member() {
          with no failure to notice.",
     );
 }
+
+/// A package nested under `.claude/worktrees/` has to resolve standalone.
+///
+/// Claude Code parks git worktrees there, physically inside this checkout. A
+/// worktree on a branch that predates the `[workspace]` section has none of
+/// its own, so cargo walks up from the nested package, lands on this crate's
+/// manifest, and — if the path is neither member nor excluded — refuses to
+/// build the worktree at all: "current package believes it's in a workspace
+/// when it's not". The `exclude` entry is what keeps such worktrees buildable.
+///
+/// Exercised with a throwaway package rather than by reading the manifest,
+/// for the same reason as above: exclusion is resolution behavior (it covers
+/// everything beneath the excluded directory), and only cargo can say whether
+/// it applies.
+#[test]
+fn packages_under_claude_worktrees_resolve_standalone() {
+    let probe = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(".claude/worktrees")
+        .join(format!("exclusion-probe-{}", std::process::id()));
+
+    struct RemoveOnDrop(std::path::PathBuf);
+    impl Drop for RemoveOnDrop {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    std::fs::create_dir_all(probe.join("src")).expect("create probe package dir");
+    let _cleanup = RemoveOnDrop(probe.clone());
+    std::fs::write(
+        probe.join("Cargo.toml"),
+        "[package]\nname = \"exclusion-probe\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write probe manifest");
+    std::fs::write(probe.join("src/lib.rs"), "").expect("write probe lib.rs");
+
+    let out = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .current_dir(&probe)
+        .output()
+        .expect("cargo metadata runs");
+    assert!(
+        out.status.success(),
+        "a package under .claude/worktrees/ no longer resolves standalone — \
+         is `.claude/worktrees` missing from this workspace's `exclude`?\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}


### PR DESCRIPTION
Claude Code parks its git worktrees under `.claude/worktrees/`, physically inside the checkout. A worktree on a branch that predates #84's `[workspace]` section has no workspace of its own, so cargo walks up from the nested package, lands on this checkout's manifest, and refuses to build the worktree entirely:

```
error: current package believes it's in a workspace when it's not
```

Observed 2026-08-02 in the #85 worktree while the main checkout carried the `[workspace]` table. Any worktree cut from current `main` is immune (its own manifest is a workspace root), but every worktree on a pre-#84 branch — including #85's — hits this on any cargo command.

## Two changes, one of them a footgun

- `exclude = [".claude/worktrees"]` in the `[workspace]` table.
- **`.` dropped from `members`.** This one is load-bearing and non-obvious: cargo decides exclusion as "under an excluded path *and not under a member path*", and both are prefix checks, so the literal `.` made every path in the checkout count as a member prefix and silently defeated `exclude`. (The guard test caught this — my first attempt kept `.` and the exclusion simply didn't apply.) The root package remains a workspace member regardless, by virtue of hosting the `[workspace]` section; the existing membership guard in `tests/workspace.rs` still passes, so #84's coverage fix is intact.

## Guard

Following `tests/workspace.rs`'s own philosophy (assert resolved behavior, not manifest text), the exclusion gets the same treatment as the membership: a test materializes a throwaway package under `.claude/worktrees/`, runs `cargo metadata` in it, and asserts it resolves standalone. If someone re-adds `.` to `members` or deletes the `exclude`, the test fails with the original error message.

## Verification

- `cargo test` in the fix worktree: all suites green, including both workspace guards.
- `cargo test` from inside the #85 worktree (whose manifest predates the `[workspace]` section) with this manifest in the outer checkout: previously the hard error above, now all suites green.

One caveat for local runs: the probe test walks *all* ancestor manifests, so inside a nested worktree it only passes once the outer checkout's branch also carries this exclusion — i.e. after this merges and `main` is pulled. On CI's flat checkout it passes as of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)